### PR TITLE
feature/conversation entry response processing

### DIFF
--- a/app/models/raif/conversation.rb
+++ b/app/models/raif/conversation.rb
@@ -44,6 +44,12 @@ class Raif::Conversation < Raif::ApplicationRecord
     )
   end
 
+  def process_model_response_message(message:, entry:)
+    # no-op by default.
+    # Override in subclasses for type-specific processing of the model response message
+    message
+  end
+
   def llm_messages
     messages = []
 

--- a/app/models/raif/conversation_entry.rb
+++ b/app/models/raif/conversation_entry.rb
@@ -76,7 +76,7 @@ private
   def extract_message_and_invoke_tools!
     transaction do
       self.raw_response = raif_model_completion.raw_response
-      self.model_response_message = raif_model_completion.parsed_response
+      self.model_response_message = raif_conversation.process_model_response_message(message: raif_model_completion.parsed_response, entry: self)
       save!
 
       if raif_model_completion.response_tool_calls.present?

--- a/app/models/raif/model_tool_invocation.rb
+++ b/app/models/raif/model_tool_invocation.rb
@@ -29,10 +29,7 @@ class Raif::ModelToolInvocation < Raif::ApplicationRecord
   def result_llm_message
     return unless tool.respond_to?(:observation_for_invocation)
 
-    observation = tool.observation_for_invocation(self)
-    return if observation.blank?
-
-    "Result from #{tool_name}: #{observation}"
+    tool.observation_for_invocation(self)
   end
 
   def to_partial_path

--- a/lib/generators/raif/conversation/templates/conversation.rb.tt
+++ b/lib/generators/raif/conversation/templates/conversation.rb.tt
@@ -27,6 +27,13 @@ module Raif
       # def initial_chat_message
       #   I18n.t("#{self.class.name.underscore.gsub("/", ".")}.initial_chat_message")
       # end
+
+      # This method will be called when receing a model response to a Raif::ConversationEntry
+      # By default, it just passes the model response message through, but you can override
+      # for custom response message processing
+      # def process_model_response_message(message:, entry:)
+      #   message
+      # end
     end
   end
 end 

--- a/spec/models/raif/conversation_spec.rb
+++ b/spec/models/raif/conversation_spec.rb
@@ -88,4 +88,12 @@ RSpec.describe Raif::Conversation, type: :model do
       expect(completion.response_format).to eq("text")
     end
   end
+
+  describe "#process_model_response_message" do
+    it "allows for conversation type-specific processing of the model response message" do
+      conversation = FB.create(:raif_test_conversation, creator: creator)
+      entry = FB.create(:raif_conversation_entry, raif_conversation: conversation, creator: creator)
+      expect(conversation.process_model_response_message(message: "Hello jerk.", entry: entry)).to eq("Hello [REDACTED].")
+    end
+  end
 end

--- a/spec/models/raif/conversation_spec.rb
+++ b/spec/models/raif/conversation_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Raif::Conversation, type: :model do
         { "role" => "assistant", "content" => entry1.model_response_message },
         { "role" => "user", "content" => entry2.user_message },
         { "role" => "assistant", "content" => "Invoking tool: #{mti.tool_name} with arguments: #{mti.tool_arguments.to_json}" },
-        { "role" => "assistant", "content" => "Result from #{mti.tool_name}: Mock Observation for #{mti.id}. Result was: success" },
+        { "role" => "assistant", "content" => "Mock Observation for #{mti.id}. Result was: success" },
         { "role" => "user", "content" => entry3.user_message },
         { "role" => "assistant", "content" => entry3.model_response_message },
         { "role" => "assistant", "content" => "Invoking tool: #{mti2.tool_name} with arguments: #{mti2.tool_arguments.to_json}" }

--- a/spec/support/test_conversation.rb
+++ b/spec/support/test_conversation.rb
@@ -11,4 +11,8 @@ class Raif::TestConversation < Raif::Conversation
     ]
   end
 
+  def process_model_response_message(message:, entry:)
+    message.gsub("jerk", "[REDACTED]")
+  end
+
 end


### PR DESCRIPTION
- **Allow conversation types to do custom processing of model response messages**
- **Remove hard coded part of result message, instead letting the observation define fully what it wants delivered to the model**
