### PR TITLE
Align file and class name to fix error on file loading

### DIFF
--- a/lib/raif/engine.rb
+++ b/lib/raif/engine.rb
@@ -84,7 +84,7 @@ module Raif
       Raif.config.conversation_types += ["Raif::TestConversation"]
 
       require "#{Raif::Engine.root}/spec/support/test_llm"
-      Raif.register_llm(Raif::Llms::Test, key: :raif_test_llm, api_name: "raif-test-llm")
+      Raif.register_llm(Raif::Llms::TestLlm, key: :raif_test_llm, api_name: "raif-test-llm")
 
       require "#{Raif::Engine.root}/spec/support/test_embedding_model"
       Raif.register_embedding_model(

--- a/spec/models/raif/llm_spec.rb
+++ b/spec/models/raif/llm_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Raif::Llm, type: :model do
     let(:system_prompt) { "You are a helpful assistant." }
 
     let(:test_llm) do
-      Raif::Llms::Test.new(key: :raif_test_llm, api_name: "test_api")
+      Raif::Llms::TestLlm.new(key: :raif_test_llm, api_name: "test_api")
     end
 
     context "when llm_api_requests_enabled is false" do

--- a/spec/support/test_llm.rb
+++ b/spec/support/test_llm.rb
@@ -2,7 +2,7 @@
 
 module Raif
   module Llms
-    class Test < Raif::Llm
+    class TestLlm < Raif::Llm
       include Raif::Concerns::Llms::OpenAi::MessageFormatting
 
       attr_accessor :chat_handler


### PR DESCRIPTION
Class defined in `spec/support/test_llm` has a name of `Test` which breaks the file loading mechanism when in test env. Class was renamed to TestLlm to align it with file name and references to it were changed.