### PR TITLE
feature/only merge main from dev

### DIFF
--- a/.github/workflows/only-merge-main-from-dev.yml
+++ b/.github/workflows/only-merge-main-from-dev.yml
@@ -1,0 +1,22 @@
+name: Only allow merging from dev to main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  enforce-dev-only-merges:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from dev branch
+        run: |
+          echo "Target branch: ${{ github.base_ref }}"
+          echo "Source branch: ${{ github.head_ref }}"
+
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "❌ Only pull requests from 'dev' to 'main' are allowed."
+            exit 1
+          fi
+
+          echo "✅ PR is from 'dev' to 'main'. Proceeding..."


### PR DESCRIPTION
Add a Github Action check that will fail if you try to merge into main from any branch other than dev.