### PR TITLE
Capture upstream HTTP response on Faraday failures

### DIFF
--- a/app/models/raif/model_completion.rb
+++ b/app/models/raif/model_completion.rb
@@ -14,6 +14,8 @@
 #  failed_at                   :datetime
 #  failure_error               :string
 #  failure_reason              :text
+#  failure_response_body       :text
+#  failure_response_status     :integer
 #  llm_model_key               :string           not null
 #  max_completion_tokens       :integer
 #  messages                    :jsonb            not null
@@ -105,10 +107,32 @@ class Raif::ModelCompletion < Raif::ApplicationRecord
     end
   end
 
+  # Maximum number of characters of an upstream HTTP body we persist on
+  # failure. The body usually carries the provider's actual error reason
+  # (e.g. OpenAI/Anthropic structured error JSON), which `failure_reason`
+  # cannot fit in 255 chars. 4 KB is enough to capture realistic error
+  # payloads without bloating storage.
+  FAILURE_RESPONSE_BODY_MAX_CHARS = 4_000
+
   def record_failure!(exception)
     self.failed_at = Time.current
     self.failure_error = exception.class.name
     self.failure_reason = exception.message.truncate(255)
+    # Always clear before re-populating so a second call with a different
+    # exception kind doesn't leave stale response metadata attached.
+    self.failure_response_status = nil
+    self.failure_response_body = nil
+
+    # Faraday errors carry the provider's HTTP status and response body —
+    # the latter is where the actual provider-side error reason lives. Both
+    # are nil when the failure happened before a response was received
+    # (DNS/connection refused/timeout).
+    if exception.is_a?(Faraday::Error)
+      self.failure_response_status = exception.response_status
+      body = exception.response_body
+      self.failure_response_body = body.to_s.first(FAILURE_RESPONSE_BODY_MAX_CHARS) if body.present?
+    end
+
     save!
   end
 

--- a/db/migrate/20260505174900_add_failure_response_to_raif_model_completions.rb
+++ b/db/migrate/20260505174900_add_failure_response_to_raif_model_completions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFailureResponseToRaifModelCompletions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :raif_model_completions, :failure_response_status, :integer
+    add_column :raif_model_completions, :failure_response_body, :text
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_07_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_174900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -126,6 +126,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_07_000000) do
     t.datetime "failed_at"
     t.string "failure_error"
     t.text "failure_reason"
+    t.text "failure_response_body"
+    t.integer "failure_response_status"
     t.string "llm_model_key", null: false
     t.integer "max_completion_tokens"
     t.jsonb "messages", null: false

--- a/spec/models/raif/llm_spec.rb
+++ b/spec/models/raif/llm_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe Raif::Llm, type: :model do
         expect(mc.failure_reason).to eq("Connection failed")
       end
 
+      it "persists upstream HTTP status and response body when a Faraday::Error carries a response" do
+        allow(Raif.config).to receive(:llm_request_retriable_exceptions).and_return([])
+        body = '{"error":{"message":"input tokens exceed maximum","type":"invalid_request_error"}}'
+        faraday_error = Faraday::BadRequestError.new(
+          "the server responded with status 400",
+          { status: 400, headers: {}, body: body }
+        )
+        allow(test_llm).to receive(:perform_model_completion!).and_raise(faraday_error)
+
+        expect do
+          test_llm.chat(messages: messages, system_prompt: system_prompt)
+        end.to raise_error(Faraday::BadRequestError)
+
+        mc = Raif::ModelCompletion.newest_first.first
+        expect(mc.failed?).to be true
+        expect(mc.failure_response_status).to eq(400)
+        expect(mc.failure_response_body).to eq(body)
+      end
+
       it "records failure when StandardError occurs" do
         allow(Raif.config).to receive(:llm_request_retriable_exceptions).and_return([])
         allow(test_llm).to receive(:perform_model_completion!).and_raise(StandardError.new("Unexpected error"))

--- a/spec/models/raif/model_completion_spec.rb
+++ b/spec/models/raif/model_completion_spec.rb
@@ -567,6 +567,75 @@ RSpec.describe Raif::ModelCompletion, type: :model do
         expect(reloaded.failure_error).to eq("StandardError")
         expect(reloaded.failure_reason).to eq("Test error")
       end
+
+      context "when the exception is a Faraday::Error with a response" do
+        let(:body) { '{"error":{"message":"Invalid request: input tokens exceed max"}}' }
+        let(:exception) do
+          Faraday::BadRequestError.new(
+            "the server responded with status 400",
+            { status: 400, headers: {}, body: body }
+          )
+        end
+
+        it "stores the response status and body" do
+          model_completion.record_failure!(exception)
+
+          expect(model_completion.failure_error).to eq("Faraday::BadRequestError")
+          expect(model_completion.failure_response_status).to eq(400)
+          expect(model_completion.failure_response_body).to eq(body)
+        end
+
+        it "truncates a body longer than FAILURE_RESPONSE_BODY_MAX_CHARS" do
+          long_body = "x" * (described_class::FAILURE_RESPONSE_BODY_MAX_CHARS + 1_000)
+          exception = Faraday::BadRequestError.new(
+            "the server responded with status 400",
+            { status: 400, headers: {}, body: long_body }
+          )
+
+          model_completion.record_failure!(exception)
+
+          expect(model_completion.failure_response_body.length).to eq(described_class::FAILURE_RESPONSE_BODY_MAX_CHARS)
+        end
+      end
+
+      context "when the exception is a Faraday::Error with no response (e.g. ConnectionFailed)" do
+        it "leaves failure_response_status and failure_response_body nil" do
+          exception = Faraday::ConnectionFailed.new("Connection refused")
+
+          model_completion.record_failure!(exception)
+
+          expect(model_completion.failure_error).to eq("Faraday::ConnectionFailed")
+          expect(model_completion.failure_response_status).to be_nil
+          expect(model_completion.failure_response_body).to be_nil
+        end
+      end
+
+      context "when the exception is not a Faraday::Error" do
+        it "leaves failure_response_status and failure_response_body nil" do
+          model_completion.record_failure!(StandardError.new("kaboom"))
+
+          expect(model_completion.failure_response_status).to be_nil
+          expect(model_completion.failure_response_body).to be_nil
+        end
+      end
+
+      context "when called twice with different exception kinds" do
+        it "clears stale response metadata from a prior Faraday failure" do
+          first = Faraday::BadRequestError.new(
+            "the server responded with status 400",
+            { status: 400, headers: {}, body: '{"error":"first"}' }
+          )
+          model_completion.record_failure!(first)
+          expect(model_completion.failure_response_status).to eq(400)
+          expect(model_completion.failure_response_body).to eq('{"error":"first"}')
+
+          model_completion.record_failure!(StandardError.new("subsequent failure"))
+
+          expect(model_completion.failure_error).to eq("StandardError")
+          expect(model_completion.failure_response_status).to be_nil
+          expect(model_completion.failure_response_body).to be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Changes

- New columns on `raif_model_completions`:
  - `failure_response_status` (integer)
  - `failure_response_body` (text)
- `record_failure!` now branches on `Faraday::Error`:
  - Captures `e.response_status` and `e.response_body`
  - Body is capped at `FAILURE_RESPONSE_BODY_MAX_CHARS` (4 KB) which should be large enough for realistic provider error payloads, bounded for storage
  - Both fields are `nil` when the failure occurred before a response was received (DNS / connection refused / timeout)
  - Stale response metadata from a prior call is cleared before the Faraday branch so re-invocation with a different exception kind doesn't leave the model in an inconsistent state

## Why a separate column instead of widening `failure_reason`?

`failure_reason` is `:string(255)` and represents the exception's own message ("the server responded with status XXX for POST <url>"). The response body is different, it's a payload from the provider, not the Ruby exception's message. Keeping them separate lets us index and filter on `failure_response_status` (e.g. "all 400s last week") and keeps `failure_reason` free of body bloat.