### PR TITLE
Stop HTML-escaping <%= %> output in prompt templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /pkg/
 /tmp/
 /spec/dummy/log/*.log
+/spec/dummy/log/*.log.*
 /spec/dummy/storage/
 /spec/dummy/tmp/
 /spec/examples.txt

--- a/lib/raif/engine.rb
+++ b/lib/raif/engine.rb
@@ -21,6 +21,20 @@ module Raif
       Mime::Type.register("application/x-raif-system-prompt", :system_prompt, [], [], true) unless Mime::Type.lookup_by_extension(:system_prompt)
     end
 
+    # Prompt templates are plain-text LLM input, not HTML. Without this,
+    # `<%= some_method %>` in a .prompt.erb / .system_prompt.erb would
+    # HTML-escape the result (e.g. " => &quot;, ' => &#39;), corrupting
+    # the prompt sent to the model. Rails' ERB handler skips escaping only
+    # for mime types in `escape_ignore_list`, which defaults to ["text/plain"].
+    initializer "raif.prompt_template_escape_ignore", after: "raif.prompt_template_formats" do
+      ActiveSupport.on_load(:action_view) do
+        ActionView::Template::Handlers::ERB.escape_ignore_list += [
+          "application/x-raif-prompt",
+          "application/x-raif-system-prompt"
+        ]
+      end
+    end
+
     # If the host app is using FactoryBot, add the factories to the host app so they can be used in host apptests
     if defined?(FactoryBotRails)
       config.factory_bot.definition_file_paths += [File.expand_path("../../../spec/factories/shared", __FILE__)]

--- a/spec/models/raif/concerns/has_prompt_templates_spec.rb
+++ b/spec/models/raif/concerns/has_prompt_templates_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe Raif::Concerns::HasPromptTemplates do
         task = Raif::TestTemplateTask.new
         expect(task.build_prompt).to eq("Tell me a joke about the topic of pirates.")
       end
+
+      # Regression: prompt templates are plain-text LLM input, so `<%= %>`
+      # output must not be HTML-escaped. Without escape_ignore_list covering
+      # the raif prompt mime types, " becomes &quot; and ' becomes &#39;,
+      # corrupting the prompt sent to the model.
+      it "does not HTML-escape interpolated content with quotes or apostrophes" do
+        task = Raif::TestTemplateTask.new(topic: %q(cats "and" dogs's))
+        expect(task.build_prompt).to eq(%q(Tell me a joke about the topic of cats "and" dogs's.))
+      end
     end
 
     context "when no template exists but build_prompt is overridden" do


### PR DESCRIPTION
## Summary

PR #458 (commit ea955f5) changed the `:prompt` and `:system_prompt` mime types from `text/plain` to custom `application/x-raif-*` types so they can't be selected via the HTTP Accept header. Unintended side effect: Rails' ActionView ERB handler skips HTML escaping only for mime types in `escape_ignore_list`, which defaults to `["text/plain"]`. The new types aren't in that list, so `<%= some_method %>` in a `.prompt.erb` / `.system_prompt.erb` started escaping any returned string -- `"` => `&quot;`, `'` => `&#39;` -- corrupting the prompt sent to the LLM.

This affects every consumer using `<%= %>` to interpolate non-trivial strings into a prompt template. ARC's CI broke on dozens of task specs as soon as it picked up the raif rev that included #458.

## Fix

Add a new initializer (`raif.prompt_template_escape_ignore`) that appends both raif prompt mime types to `ActionView::Template::Handlers::ERB.escape_ignore_list`. Wrapped in `ActiveSupport.on_load(:action_view)` so it runs after ActionView has loaded the ERB handler.

## Regression coverage

Added one targeted spec to `spec/models/raif/concerns/has_prompt_templates_spec.rb` that interpolates a topic containing `"` and `'` characters and asserts the rendered prompt round-trips them literally. Confirmed the spec fails on `main` (output: `cats &quot;and&quot; dogs&#39;s.`) and passes with the fix.

Full suite green: 1,209 examples, 0 failures.

## Test plan

- [x] New regression spec passes with fix, fails without it
- [x] Full raif spec suite passes
- [ ] Once merged, bump raif rev in ARC and remove the temporary `escape_ignore_list` workaround in `arc/config/initializers/raif.rb`
