### PR TITLE
Track latest_entry_at on conversations and surface in admin list

### DIFF
--- a/app/controllers/raif/admin/conversations_controller.rb
+++ b/app/controllers/raif/admin/conversations_controller.rb
@@ -4,7 +4,7 @@ module Raif
   module Admin
     class ConversationsController < Raif::Admin::ApplicationController
       def index
-        @pagy, @conversations = pagy(Raif::Conversation.order(created_at: :desc))
+        @pagy, @conversations = pagy(Raif::Conversation.order(Arel.sql("latest_entry_at DESC NULLS LAST, created_at DESC")))
       end
 
       def show

--- a/app/controllers/raif/admin/conversations_controller.rb
+++ b/app/controllers/raif/admin/conversations_controller.rb
@@ -4,7 +4,7 @@ module Raif
   module Admin
     class ConversationsController < Raif::Admin::ApplicationController
       def index
-        @pagy, @conversations = pagy(Raif::Conversation.order(Arel.sql("latest_entry_at DESC NULLS LAST, created_at DESC")))
+        @pagy, @conversations = pagy(Raif::Conversation.order(Arel.sql("latest_entry_at IS NULL, latest_entry_at DESC, created_at DESC")))
       end
 
       def show

--- a/app/models/raif/conversation.rb
+++ b/app/models/raif/conversation.rb
@@ -10,6 +10,7 @@
 #  conversation_entries_count :integer          default(0), not null
 #  creator_type               :string           not null
 #  generating_entry_response  :boolean          default(FALSE), not null
+#  latest_entry_at            :datetime
 #  llm_messages_max_length    :integer
 #  llm_model_key              :string           not null
 #  requested_language_key     :string

--- a/app/models/raif/conversation_entry.rb
+++ b/app/models/raif/conversation_entry.rb
@@ -70,6 +70,7 @@ class Raif::ConversationEntry < Raif::ApplicationRecord
   boolean_timestamp :failed_at
 
   before_validation :add_user_tool_invocation_to_user_message, on: :create
+  after_create_commit :update_conversation_latest_entry_at
 
   normalizes :model_response_message, with: ->(value) { value&.strip }
   normalizes :user_message, with: ->(value) { value&.strip }
@@ -78,6 +79,10 @@ class Raif::ConversationEntry < Raif::ApplicationRecord
     return unless raif_user_tool_invocation.present?
 
     self.user_message = [user_message, raif_user_tool_invocation.as_user_message].join("\n\n")
+  end
+
+  def update_conversation_latest_entry_at
+    raif_conversation.update_column(:latest_entry_at, created_at)
   end
 
   def response_format

--- a/app/views/raif/admin/conversations/_conversation.html.erb
+++ b/app/views/raif/admin/conversations/_conversation.html.erb
@@ -1,6 +1,6 @@
 <tr id="<%= dom_id(conversation) %>" class="raif-conversation">
   <td><%= link_to "##{conversation.id}", raif.admin_conversation_path(conversation) %></td>
-  <td><small class="text-muted"><%= conversation.created_at.rfc822 %></small></td>
+  <td><small class="text-muted"><%= conversation.latest_entry_at&.rfc822 %></small></td>
   <td><%= conversation.creator.try(:raif_display_name) || "#{conversation.creator_type} ##{conversation.creator_id}" %></td>
   <td><%= conversation.type %></td>
   <td><%= conversation.conversation_entries_count %></td>

--- a/app/views/raif/admin/conversations/index.html.erb
+++ b/app/views/raif/admin/conversations/index.html.erb
@@ -8,7 +8,7 @@
           <thead class="table-light">
             <tr>
               <th><%= t("raif.admin.common.id") %></th>
-              <th><%= t("raif.admin.common.created_at") %></th>
+              <th><%= t("raif.admin.common.latest_entry_at") %></th>
               <th><%= t("raif.admin.common.creator") %></th>
               <th><%= t("raif.admin.common.type") %></th>
               <th><%= t("raif.admin.common.entries_count") %></th>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -52,6 +52,7 @@ en:
         invocations: Invocations
         iterations: Iterations
         language: Language
+        latest_entry_at: Latest Entry At
         llms: LLMs
         messages: Messages
         model: Model

--- a/db/migrate/20260514000000_add_latest_entry_at_to_raif_conversations.rb
+++ b/db/migrate/20260514000000_add_latest_entry_at_to_raif_conversations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLatestEntryAtToRaifConversations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :raif_conversations, :latest_entry_at, :datetime
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_174900) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -101,6 +101,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_174900) do
     t.bigint "creator_id", null: false
     t.string "creator_type", null: false
     t.boolean "generating_entry_response", default: false, null: false
+    t.datetime "latest_entry_at"
     t.integer "llm_messages_max_length"
     t.string "llm_model_key", null: false
     t.string "requested_language_key"

--- a/spec/features/raif/admin/conversations_spec.rb
+++ b/spec/features/raif/admin/conversations_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admin::Conversations", type: :feature do
       # Check page title and table headers
       expect(page).to have_content(I18n.t("raif.admin.common.conversations"))
       expect(page).to have_content(I18n.t("raif.admin.common.id"))
-      expect(page).to have_content(I18n.t("raif.admin.common.created_at"))
+      expect(page).to have_content(I18n.t("raif.admin.common.latest_entry_at"))
       expect(page).to have_content(I18n.t("raif.admin.common.creator"))
       expect(page).to have_content(I18n.t("raif.admin.common.type"))
       expect(page).to have_content(I18n.t("raif.admin.common.entries_count"))

--- a/spec/models/raif/conversation_entry_spec.rb
+++ b/spec/models/raif/conversation_entry_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe Raif::ConversationEntry, type: :model do
     end.to change { conversation.reload.conversation_entries_count }.by(1)
   end
 
+  it "updates the conversation's latest_entry_at when a new entry is added" do
+    conversation = FB.create(:raif_conversation, creator: creator)
+    expect(conversation.latest_entry_at).to be_nil
+
+    first_entry = conversation.entries.create!(creator: conversation.creator)
+    expect(conversation.reload.latest_entry_at).to be_within(1.second).of(first_entry.created_at)
+
+    later_entry = conversation.entries.create!(creator: conversation.creator, created_at: 1.hour.from_now)
+    expect(conversation.reload.latest_entry_at).to be_within(1.second).of(later_entry.created_at)
+  end
+
   describe "#add_user_tool_invocation_to_user_message" do
     let(:conversation) { FB.create(:raif_test_conversation, creator: creator) }
 

--- a/spec/models/raif/conversation_spec.rb
+++ b/spec/models/raif/conversation_spec.rb
@@ -10,6 +10,7 @@
 #  conversation_entries_count :integer          default(0), not null
 #  creator_type               :string           not null
 #  generating_entry_response  :boolean          default(FALSE), not null
+#  latest_entry_at            :datetime
 #  llm_messages_max_length    :integer
 #  llm_model_key              :string           not null
 #  requested_language_key     :string

--- a/spec/models/raif/model_completion_spec.rb
+++ b/spec/models/raif/model_completion_spec.rb
@@ -14,6 +14,8 @@
 #  failed_at                      :datetime
 #  failure_error                  :string
 #  failure_reason                 :text
+#  failure_response_body          :text
+#  failure_response_status        :integer
 #  llm_model_key                  :string           not null
 #  max_completion_tokens          :integer
 #  messages                       :jsonb            not null


### PR DESCRIPTION
Adds a latest_entry_at column to raif_conversations, kept current via an
after_create_commit on Raif::ConversationEntry. The admin conversations
index replaces the Created At column with Latest Entry At and orders by
it (NULLS LAST) so the busiest threads float to the top.
