### PR TITLE
Count provider-managed tool calls in agent admin

### DIFF
--- a/app/models/raif/agent.rb
+++ b/app/models/raif/agent.rb
@@ -160,6 +160,32 @@ module Raif
       iteration_count == max_iterations
     end
 
+    # Per-tool invocation counts for the admin agent show page, keyed by tool
+    # class name (e.g. "Raif::ModelTools::ProviderManaged::WebSearch") so the
+    # `_list` partial can look up `counts[tool_class.name]`.
+    #
+    # Combines two sources:
+    # - Developer-managed tools persist as Raif::ModelToolInvocation rows via
+    #   Raif::ModelTool.invoke_tool.
+    # - Provider-managed tools (e.g. Anthropic / OpenAI web_search) never reach
+    #   that path - they live as `server_tool_use` / `web_search_call` blocks
+    #   in each completion's `response_array` and are surfaced via
+    #   ModelCompletion#provider_managed_tool_calls.
+    def model_tool_invocation_counts
+      counts = raif_model_tool_invocations.group(:tool_type).count
+
+      raif_model_completions.find_each do |completion|
+        Array(completion.provider_managed_tool_calls).each do |call|
+          tool_klass = completion.available_model_tools_map[call["tool_name"]]
+          next unless tool_klass
+
+          counts[tool_klass.name] = (counts[tool_klass.name] || 0) + 1
+        end
+      end
+
+      counts
+    end
+
   private
 
     def populate_default_model_tools

--- a/app/views/raif/admin/agents/show.html.erb
+++ b/app/views/raif/admin/agents/show.html.erb
@@ -98,7 +98,7 @@
 
 <%= render "raif/admin/model_tools/list",
       model_tools: @agent.available_model_tools_map,
-      invocation_counts: @agent.raif_model_tool_invocations.group(:tool_type).count %>
+      invocation_counts: @agent.model_tool_invocation_counts %>
 
 <div class="card mb-4">
   <div class="card-header">

--- a/spec/models/raif/agent_spec.rb
+++ b/spec/models/raif/agent_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Raif::Agent, type: :model do
+  let(:creator) { FB.create(:raif_test_user) }
+
+  describe "#model_tool_invocation_counts" do
+    let(:agent) do
+      FB.create(
+        :raif_native_tool_calling_agent,
+        creator: creator,
+        system_prompt: "System prompt",
+        available_model_tools: [
+          "Raif::ModelTools::WikipediaSearch",
+          "Raif::ModelTools::ProviderManaged::WebSearch",
+        ]
+      )
+    end
+
+    it "combines developer-managed invocation rows with provider-managed tool calls extracted from completions" do
+      FB.create(:raif_model_tool_invocation, source: agent)
+      FB.create(:raif_model_tool_invocation, source: agent)
+
+      FB.create(
+        :raif_model_completion,
+        source: agent,
+        llm_model_key: "anthropic_claude_3_5_haiku",
+        model_api_name: "claude-3-5-haiku-20241022",
+        available_model_tools: ["Raif::ModelTools::ProviderManaged::WebSearch"],
+        response_array: [
+          { "type" => "server_tool_use", "id" => "srvtoolu_1", "name" => "web_search", "input" => { "query" => "q1" } },
+          { "type" => "server_tool_use", "id" => "srvtoolu_2", "name" => "web_search", "input" => { "query" => "q2" } },
+        ]
+      )
+
+      FB.create(
+        :raif_model_completion,
+        source: agent,
+        llm_model_key: "anthropic_claude_3_5_haiku",
+        model_api_name: "claude-3-5-haiku-20241022",
+        available_model_tools: ["Raif::ModelTools::ProviderManaged::WebSearch"],
+        response_array: [
+          { "type" => "server_tool_use", "id" => "srvtoolu_3", "name" => "web_search", "input" => { "query" => "q3" } },
+        ]
+      )
+
+      expect(agent.model_tool_invocation_counts).to eq(
+        "Raif::TestModelTool" => 2,
+        "Raif::ModelTools::ProviderManaged::WebSearch" => 3
+      )
+    end
+
+    it "ignores provider-managed tool calls for tools not registered on the completion" do
+      FB.create(
+        :raif_model_completion,
+        source: agent,
+        llm_model_key: "anthropic_claude_3_5_haiku",
+        model_api_name: "claude-3-5-haiku-20241022",
+        available_model_tools: [],
+        response_array: [
+          { "type" => "server_tool_use", "id" => "srvtoolu_1", "name" => "web_search", "input" => { "query" => "q1" } },
+        ]
+      )
+
+      expect(agent.model_tool_invocation_counts).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
The agent admin show page previously counted tool usage only from persisted `raif_model_tool_invocations` rows grouped by `tool_type`.

Provider-managed tools such as web search, code execution, and image generation do not go through `Raif::ModelTool.invoke_tool`, so they never create invocation rows. Their calls are stored in each completion's `response_array` as provider-specific blocks such as `server_tool_use` or `web_search_call`, which meant those tools always rendered with a count of `0`.

This adds `Raif::Agent#model_tool_invocation_counts`, which combines persisted invocation rows with provider-managed calls parsed from associated model completions. Counts are keyed by tool class name, so the existing admin model tools partial can render them unchanged.

## Changes

- Add `Raif::Agent#model_tool_invocation_counts`
- Update the agent admin show page to use the combined count source
- Add model specs covering persisted and provider-managed invocation counts