### PR TITLE
Link agent admin tool calls to invocation pages

### DIFF
--- a/app/views/raif/admin/agents/_conversation_message.html.erb
+++ b/app/views/raif/admin/agents/_conversation_message.html.erb
@@ -3,7 +3,13 @@
   <div class="message-header d-flex justify-content-between align-items-center mb-2 px-2">
     <strong class="<%= conversation_message_header_class(message) %>">
       <% if message_type == "tool_call" %>
-        <%= t("raif.admin.common.tool_call") %>: <%= message["name"] %>
+        <% invocation = invocations_by_call_id[message["provider_tool_call_id"]] %>
+        <%= t("raif.admin.common.tool_call") %>:
+        <% if invocation %>
+          <%= link_to message["name"], raif.admin_model_tool_invocation_path(invocation) %>
+        <% else %>
+          <%= message["name"] %>
+        <% end %>
       <% elsif message_type == "tool_call_result" %>
         <%= t("raif.admin.common.tool_result") %>
       <% else %>

--- a/app/views/raif/admin/agents/_conversation_message.html.erb
+++ b/app/views/raif/admin/agents/_conversation_message.html.erb
@@ -3,7 +3,7 @@
   <div class="message-header d-flex justify-content-between align-items-center mb-2 px-2">
     <strong class="<%= conversation_message_header_class(message) %>">
       <% if message_type == "tool_call" %>
-        <% invocation = invocations_by_call_id[message["provider_tool_call_id"]] %>
+        <% invocation = invocations_by_call_id[message["provider_tool_call_id"].presence] %>
         <%= t("raif.admin.common.tool_call") %>:
         <% if invocation %>
           <%= link_to message["name"], raif.admin_model_tool_invocation_path(invocation) %>

--- a/app/views/raif/admin/agents/show.html.erb
+++ b/app/views/raif/admin/agents/show.html.erb
@@ -130,6 +130,7 @@
 </div>
 
 <% if @agent.conversation_history.present? %>
+  <% invocations_by_call_id = @agent.raif_model_tool_invocations.index_by(&:provider_tool_call_id) %>
   <div class="card mb-4 conversation-card">
     <div class="card-header">
       <h5 class="mb-0"><%= t("raif.admin.common.conversation_history") %></h5>
@@ -141,7 +142,8 @@
                 locals: {
                   message: message,
                   message_count: index + 1,
-                  is_final_answer: message["type"] == "tool_call" && message["name"] == "agent_final_answer"
+                  is_final_answer: message["type"] == "tool_call" && message["name"] == "agent_final_answer",
+                  invocations_by_call_id: invocations_by_call_id
                 } %>
         <% end %>
       </div>

--- a/app/views/raif/admin/agents/show.html.erb
+++ b/app/views/raif/admin/agents/show.html.erb
@@ -130,7 +130,7 @@
 </div>
 
 <% if @agent.conversation_history.present? %>
-  <% invocations_by_call_id = @agent.raif_model_tool_invocations.index_by(&:provider_tool_call_id) %>
+  <% invocations_by_call_id = @agent.raif_model_tool_invocations.where.not(provider_tool_call_id: nil).index_by(&:provider_tool_call_id) %>
   <div class="card mb-4 conversation-card">
     <div class="card-header">
       <h5 class="mb-0"><%= t("raif.admin.common.conversation_history") %></h5>


### PR DESCRIPTION
## Summary

- Link persisted tool calls in the agent admin conversation history to their model tool invocation admin pages.
- Build the lookup by `provider_tool_call_id` and skip nil IDs so inferred/provider-managed calls do not link incorrectly.
- Keep unmatched tool calls rendered as plain text.