### PR TITLE
Add ResumeStalledModelCompletionBatchPollsJob

### DIFF
--- a/app/jobs/raif/resume_stalled_model_completion_batch_polls_job.rb
+++ b/app/jobs/raif/resume_stalled_model_completion_batch_polls_job.rb
@@ -13,7 +13,7 @@ module Raif
   # For each non-terminal batch whose next_poll_at is in the past by at least
   # POLL_GRACE, this sweep enqueues a fresh Raif::PollModelCompletionBatchJob.
   # That job is idempotent at the top (terminal? check + handler-dispatched
-  # gating), and fetch_batch_status! is a read against the provider, so a
+  # gating), and batch.fetch_status! is a read against the provider, so a
   # concurrent normally-firing poll plus this sweep at most causes a duplicate
   # provider status request.
   #

--- a/app/jobs/raif/resume_stalled_model_completion_batch_polls_job.rb
+++ b/app/jobs/raif/resume_stalled_model_completion_batch_polls_job.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Raif
+  # Recovery sweep for Raif::ModelCompletionBatch records whose self-rescheduling
+  # poll chain (Raif::PollModelCompletionBatchJob) was dropped -- e.g. a
+  # scheduled job evicted on a queue backend restart, an ActiveJob retry
+  # ceiling reached, or a deploy that drained the queue before the next poll
+  # fired. Without recovery, such batches sit non-terminal until the
+  # hourly Raif::ExpireStuckModelCompletionBatchesJob force-fails them at
+  # max_age, discarding any results the provider may have produced in the
+  # meantime.
+  #
+  # For each non-terminal batch whose next_poll_at is in the past by at least
+  # POLL_GRACE, this sweep enqueues a fresh Raif::PollModelCompletionBatchJob.
+  # That job is idempotent at the top (terminal? check + handler-dispatched
+  # gating), and fetch_batch_status! is a read against the provider, so a
+  # concurrent normally-firing poll plus this sweep at most causes a duplicate
+  # provider status request.
+  #
+  # Pairs with Raif::ExpireStuckModelCompletionBatchesJob to form a
+  # recover-then-expire pattern: host apps should schedule this sweep
+  # frequently (every ~5 minutes) and the expire sweep hourly. The resume
+  # sweep tries to reclaim results before the expire sweep declares the
+  # batch lost.
+  class ResumeStalledModelCompletionBatchPollsJob < ApplicationJob
+
+    # Skip batches whose next_poll_at landed within this window. A poll job
+    # that fires at exactly next_poll_at takes a moment to call reschedule!,
+    # so a too-small grace would race the normally-firing chain. 5 minutes
+    # is comfortably outside the tightest entry in the default poll schedule
+    # (60s) without leaving stranded batches unattended for long.
+    POLL_GRACE = 5.minutes
+
+    def perform
+      cutoff = POLL_GRACE.ago
+
+      Raif::ModelCompletionBatch
+        .due_for_poll(at: cutoff)
+        .find_each do |batch|
+          Raif::PollModelCompletionBatchJob.perform_later(batch.id)
+          Raif.logger.info(
+            "Raif::ResumeStalledModelCompletionBatchPollsJob: enqueued poll for batch ##{batch.id} " \
+              "(status=#{batch.status}, next_poll_at=#{batch.next_poll_at&.iso8601 || "nil"}, " \
+              "provider_batch_id=#{batch.provider_batch_id.inspect})"
+          )
+        rescue StandardError => e
+          # Per-batch rescue so a single bad enqueue (queue-backend hiccup,
+          # serialization failure) doesn't block recovery of every later batch
+          # in the sweep. The next tick re-enters and retries any batch that's
+          # still due_for_poll.
+          Raif.logger.error(
+            "Raif::ResumeStalledModelCompletionBatchPollsJob: failed to enqueue poll for batch ##{batch.id}: #{e.class}: #{e.message}"
+          )
+          Raif.logger.error(e.backtrace.first(20).join("\n")) if e.backtrace.present?
+
+          if defined?(Airbrake)
+            notice = Airbrake.build_notice(e)
+            notice[:context][:component] = "raif_resume_stalled_model_completion_batch_polls_job"
+            notice[:params] = { batch_id: batch.id }
+            Airbrake.notify(notice)
+          end
+        end
+    end
+
+  end
+end

--- a/docs/_learn_more/task_batching.md
+++ b/docs/_learn_more/task_batching.md
@@ -91,7 +91,7 @@ If a batch outlives `Raif.config.model_completion_batch_max_age` (default 26 hou
 
 The self-rescheduling poll chain can be lost if a scheduled job is evicted (queue backend restart, deploy that drains the queue, ActiveJob retries exhausted). Raif provides two safety sweeps that host apps should schedule together:
 
-1. `Raif::ResumeStalledModelCompletionBatchPollsJob` (run every ~5 minutes) finds non-terminal batches whose `next_poll_at` is in the past and re-enqueues `Raif::PollModelCompletionBatchJob` for each. The next poll calls `fetch_status!`, so if the provider has already finished the batch, results are reclaimed instead of being thrown away.
+1. `Raif::ResumeStalledModelCompletionBatchPollsJob` (run every ~5 minutes) finds non-terminal batches whose `next_poll_at` is more than 5 minutes in the past (a `POLL_GRACE` window that keeps the sweep from racing a normally-firing poll) and re-enqueues `Raif::PollModelCompletionBatchJob` for each. The next poll calls `fetch_status!`, so if the provider has already finished the batch, results are reclaimed instead of being thrown away.
 2. `Raif::ExpireStuckModelCompletionBatchesJob` (run hourly) is the final fallback: any non-terminal batch older than `model_completion_batch_max_age` is force-failed through the same expiry path described above.
 
 **Schedule both in your host app's cron.** The resume sweep recovers happy-path batches whose chain dropped; the expire sweep cleans up batches the provider can't or won't finalize.

--- a/docs/_learn_more/task_batching.md
+++ b/docs/_learn_more/task_batching.md
@@ -87,10 +87,22 @@ You don't usually interact with the polling job directly. Once `submit!` is call
    - **`canceled` / `expired` / `failed`**: every still-pending child is force-failed with the batch status as the reason. No per-entry fetch happens.
 4. `batch.dispatch_completion_handler!` runs your handler.
 
-If a batch outlives `Raif.config.model_completion_batch_max_age` (default 26 hours) without resolving, it's expired: raif issues a best-effort provider-side cancel via `batch.cancel!` and then force-fails the batch locally so any waiting workflow can advance. If the cancel call fails (network, 5xx, etc.), the local force-fail still happens — the provider-side batch may continue running and be billed, but raif logs and moves on. The hourly safety sweep `Raif::ExpireStuckModelCompletionBatchesJob` runs the same expiry path for batches whose polling chain was dropped entirely (e.g., a queue restart that loses scheduled jobs). **Schedule it to run hourly in your host app's cron** – without it, a stranded batch never advances.
+If a batch outlives `Raif.config.model_completion_batch_max_age` (default 26 hours) without resolving, it's expired: raif issues a best-effort provider-side cancel via `batch.cancel!` and then force-fails the batch locally so any waiting workflow can advance. If the cancel call fails (network, 5xx, etc.), the local force-fail still happens — the provider-side batch may continue running and be billed, but raif logs and moves on.
+
+The self-rescheduling poll chain can be lost if a scheduled job is evicted (queue backend restart, deploy that drains the queue, ActiveJob retries exhausted). Raif provides two safety sweeps that host apps should schedule together:
+
+1. `Raif::ResumeStalledModelCompletionBatchPollsJob` (run every ~5 minutes) finds non-terminal batches whose `next_poll_at` is in the past and re-enqueues `Raif::PollModelCompletionBatchJob` for each. The next poll calls `fetch_status!`, so if the provider has already finished the batch, results are reclaimed instead of being thrown away.
+2. `Raif::ExpireStuckModelCompletionBatchesJob` (run hourly) is the final fallback: any non-terminal batch older than `model_completion_batch_max_age` is force-failed through the same expiry path described above.
+
+**Schedule both in your host app's cron.** The resume sweep recovers happy-path batches whose chain dropped; the expire sweep cleans up batches the provider can't or won't finalize.
 
 ```yaml
 # config/schedule.yml (sidekiq-cron example)
+resume_stalled_model_completion_batch_polls:
+  cron: "*/5 * * * *"
+  class: "Raif::ResumeStalledModelCompletionBatchPollsJob"
+  queue: "default"
+
 expire_stuck_model_completion_batches:
   cron: "every hour"
   class: "Raif::ExpireStuckModelCompletionBatchesJob"

--- a/spec/jobs/raif/resume_stalled_model_completion_batch_polls_job_spec.rb
+++ b/spec/jobs/raif/resume_stalled_model_completion_batch_polls_job_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Raif::ResumeStalledModelCompletionBatchPollsJob, type: :job do
+  describe "#perform" do
+    it "enqueues a poll job for non-terminal batches whose next_poll_at is past the grace window" do
+      stalled = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "in_progress",
+        provider_batch_id: "msgbatch_stalled",
+        submitted_at: 1.hour.ago,
+        started_at: 1.hour.ago,
+        next_poll_at: 30.minutes.ago
+      )
+
+      expect do
+        described_class.perform_now
+      end.to have_enqueued_job(Raif::PollModelCompletionBatchJob).with(stalled.id)
+    end
+
+    it "skips batches that have already reached a terminal status" do
+      ended = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "ended",
+        provider_batch_id: "msgbatch_ended",
+        submitted_at: 1.hour.ago,
+        ended_at: 30.minutes.ago,
+        next_poll_at: 30.minutes.ago
+      )
+
+      expect do
+        described_class.perform_now
+      end.not_to have_enqueued_job(Raif::PollModelCompletionBatchJob).with(ended.id)
+    end
+
+    it "skips batches whose next_poll_at is in the future" do
+      not_yet_due = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "in_progress",
+        provider_batch_id: "msgbatch_future",
+        submitted_at: 5.minutes.ago,
+        started_at: 5.minutes.ago,
+        next_poll_at: 2.minutes.from_now
+      )
+
+      expect do
+        described_class.perform_now
+      end.not_to have_enqueued_job(Raif::PollModelCompletionBatchJob).with(not_yet_due.id)
+    end
+
+    it "skips batches whose next_poll_at is in the past but within the grace window" do
+      within_grace = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "in_progress",
+        provider_batch_id: "msgbatch_grace",
+        submitted_at: 10.minutes.ago,
+        started_at: 10.minutes.ago,
+        next_poll_at: 30.seconds.ago
+      )
+
+      expect do
+        described_class.perform_now
+      end.not_to have_enqueued_job(Raif::PollModelCompletionBatchJob).with(within_grace.id)
+    end
+
+    it "skips batches with a null next_poll_at (never scheduled)" do
+      no_poll = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "in_progress",
+        provider_batch_id: "msgbatch_nopoll",
+        submitted_at: 1.hour.ago,
+        started_at: 1.hour.ago,
+        next_poll_at: nil
+      )
+
+      expect do
+        described_class.perform_now
+      end.not_to have_enqueued_job(Raif::PollModelCompletionBatchJob).with(no_poll.id)
+    end
+
+    it "rescues per-batch so a single enqueue failure does not block recovery of later batches" do
+      first = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "in_progress",
+        provider_batch_id: "msgbatch_bad",
+        submitted_at: 1.hour.ago,
+        started_at: 1.hour.ago,
+        next_poll_at: 30.minutes.ago
+      )
+      second = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "in_progress",
+        provider_batch_id: "msgbatch_good",
+        submitted_at: 1.hour.ago,
+        started_at: 1.hour.ago,
+        next_poll_at: 29.minutes.ago
+      )
+
+      # find_each iterates ordered by primary key, so `first` is processed
+      # before `second`. Stub perform_later to raise for the first batch only.
+      allow(Raif::PollModelCompletionBatchJob).to receive(:perform_later).and_call_original
+      allow(Raif::PollModelCompletionBatchJob).to receive(:perform_later).with(first.id).and_raise(StandardError, "synthetic queue failure")
+      allow(Raif.logger).to receive(:error)
+
+      expect do
+        described_class.perform_now
+      end.to have_enqueued_job(Raif::PollModelCompletionBatchJob).with(second.id)
+
+      expect(Raif.logger).to have_received(:error)
+        .with(a_string_matching(/failed to enqueue poll for batch ##{first.id}.*synthetic queue failure/))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `Raif::ResumeStalledModelCompletionBatchPollsJob` recovers `Raif::ModelCompletionBatch` rows whose self-rescheduling `PollModelCompletionBatchJob` chain was dropped (queue restart, deploy, ActiveJob retries exhausted, etc.). It selects non-terminal batches whose `next_poll_at` is past a 5-minute grace and re-enqueues the poll job for each.
- The poll job is idempotent at the top (`terminal?` check + `handler_dispatched_at` gating) and `fetch_status!` is a provider read, so a concurrent normally-firing poll plus this sweep at most causes a duplicate status request.
- Pairs with `ExpireStuckModelCompletionBatchesJob` to form a recover-then-expire pattern: host apps should schedule the resume sweep every ~5 minutes and the expire sweep hourly. Without the resume sweep, a dropped chain sits non-terminal until the hourly expire sweep force-fails it at `max_age` (default 26h), discarding any results the provider may already have produced.
- Docs updated in `docs/_learn_more/task_batching.md` with the recover-then-expire pattern and a sidekiq-cron example covering both jobs.