### PR TITLE
Add admin views for model completion batches

### DIFF
--- a/app/controllers/raif/admin/model_completion_batches_controller.rb
+++ b/app/controllers/raif/admin/model_completion_batches_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Raif
+  module Admin
+    class ModelCompletionBatchesController < Raif::Admin::ApplicationController
+      def index
+        @selected_status = params[:status].presence || "all"
+        @selected_llm_model_key = params[:llm_model_key].presence
+        @selected_type = params[:type].presence
+
+        @llm_model_keys = Raif::ModelCompletionBatch.distinct.order(:llm_model_key).pluck(:llm_model_key)
+        @types = Raif::ModelCompletionBatch.distinct.order(:type).pluck(:type).compact
+
+        batches = Raif::ModelCompletionBatch.order(created_at: :desc)
+
+        if @selected_status != "all" && Raif::ModelCompletionBatch::STATUSES.include?(@selected_status)
+          batches = batches.where(status: @selected_status)
+        end
+
+        batches = batches.where(llm_model_key: @selected_llm_model_key) if @selected_llm_model_key.present?
+        batches = batches.where(type: @selected_type) if @selected_type.present?
+
+        @pagy, @model_completion_batches = pagy(batches)
+      end
+
+      def show
+        @model_completion_batch = Raif::ModelCompletionBatch.find(params[:id])
+        @model_completions = @model_completion_batch.raif_model_completions.order(:id)
+      end
+    end
+  end
+end

--- a/app/controllers/raif/admin/model_completion_batches_controller.rb
+++ b/app/controllers/raif/admin/model_completion_batches_controller.rb
@@ -21,11 +21,16 @@ module Raif
         batches = batches.where(type: @selected_type) if @selected_type.present?
 
         @pagy, @model_completion_batches = pagy(batches)
+
+        @completion_counts_by_batch_id = Raif::ModelCompletion
+          .where(raif_model_completion_batch_id: @model_completion_batches.map(&:id))
+          .group(:raif_model_completion_batch_id)
+          .count
       end
 
       def show
         @model_completion_batch = Raif::ModelCompletionBatch.find(params[:id])
-        @model_completions = @model_completion_batch.raif_model_completions.order(:id)
+        @model_completions = @model_completion_batch.raif_model_completions.order(:id).to_a
       end
     end
   end

--- a/app/views/layouts/raif/admin.html.erb
+++ b/app/views/layouts/raif/admin.html.erb
@@ -86,6 +86,16 @@
               </a>
             </li>
             <li class="nav-item">
+              <a class="nav-link <%= current_page?(raif.admin_model_completion_batches_path) ? "active" : "" %>" href="<%= raif.admin_model_completion_batches_path %>">
+                <span class="d-inline-block me-2">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-collection" viewBox="0 0 16 16">
+                    <path d="M2.5 3.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 0 1h-11zm2-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zM0 13a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 16 13V6a1.5 1.5 0 0 0-1.5-1.5h-13A1.5 1.5 0 0 0 0 6v7zm1.5.5A.5.5 0 0 1 1 13V6a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5h-13z" />
+                  </svg>
+                </span>
+                <%= t("raif.admin.common.model_completion_batches") %>
+              </a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link <%= current_page?(raif.admin_model_tool_invocations_path) ? "active" : "" %>" href="<%= raif.admin_model_tool_invocations_path %>">
                 <span class="d-inline-block me-2">
                   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-tools" viewBox="0 0 16 16">

--- a/app/views/raif/admin/model_completion_batches/_model_completion_batch.html.erb
+++ b/app/views/raif/admin/model_completion_batches/_model_completion_batch.html.erb
@@ -5,7 +5,7 @@
   <td><%= model_completion_batch.llm_model_key %></td>
   <td><small><%= model_completion_batch.provider_batch_id.presence || "-" %></small></td>
   <td><%= render "raif/admin/model_completion_batches/status_badge", model_completion_batch: model_completion_batch %></td>
-  <td><%= model_completion_batch.raif_model_completions.count %></td>
+  <td><%= completion_counts_by_batch_id.fetch(model_completion_batch.id, 0) %></td>
   <td><small class="text-muted"><%= model_completion_batch.submitted_at&.rfc822 || "-" %></small></td>
   <td><small class="text-muted"><%= model_completion_batch.ended_at&.rfc822 || "-" %></small></td>
   <td><%= model_completion_batch.total_cost ? number_to_currency(model_completion_batch.total_cost, precision: 6) : "-" %></td>

--- a/app/views/raif/admin/model_completion_batches/_model_completion_batch.html.erb
+++ b/app/views/raif/admin/model_completion_batches/_model_completion_batch.html.erb
@@ -1,0 +1,12 @@
+<tr id="<%= dom_id(model_completion_batch) %>" class="raif-model-completion-batch">
+  <td><%= link_to "##{model_completion_batch.id}", raif.admin_model_completion_batch_path(model_completion_batch) %></td>
+  <td><small class="text-muted"><%= model_completion_batch.created_at.rfc822 %></small></td>
+  <td><small><%= model_completion_batch.type %></small></td>
+  <td><%= model_completion_batch.llm_model_key %></td>
+  <td><small><%= model_completion_batch.provider_batch_id.presence || "-" %></small></td>
+  <td><%= render "raif/admin/model_completion_batches/status_badge", model_completion_batch: model_completion_batch %></td>
+  <td><%= model_completion_batch.raif_model_completions.count %></td>
+  <td><small class="text-muted"><%= model_completion_batch.submitted_at&.rfc822 || "-" %></small></td>
+  <td><small class="text-muted"><%= model_completion_batch.ended_at&.rfc822 || "-" %></small></td>
+  <td><%= model_completion_batch.total_cost ? number_to_currency(model_completion_batch.total_cost, precision: 6) : "-" %></td>
+</tr>

--- a/app/views/raif/admin/model_completion_batches/_status_badge.html.erb
+++ b/app/views/raif/admin/model_completion_batches/_status_badge.html.erb
@@ -1,0 +1,12 @@
+<% case model_completion_batch.status %>
+<% when "ended" %>
+  <span class="badge bg-success"><%= model_completion_batch.status.titleize %></span>
+<% when "failed", "expired" %>
+  <span class="badge bg-danger"><%= model_completion_batch.status.titleize %></span>
+<% when "canceled" %>
+  <span class="badge bg-secondary"><%= model_completion_batch.status.titleize %></span>
+<% when "in_progress", "submitted" %>
+  <span class="badge bg-warning text-dark"><%= model_completion_batch.status.titleize %></span>
+<% else %>
+  <span class="badge bg-light text-dark"><%= model_completion_batch.status.titleize %></span>
+<% end %>

--- a/app/views/raif/admin/model_completion_batches/index.html.erb
+++ b/app/views/raif/admin/model_completion_batches/index.html.erb
@@ -1,0 +1,79 @@
+<h1 class="my-4"><%= t("raif.admin.common.model_completion_batches") %></h1>
+
+<div class="row">
+  <div class="col-12">
+    <%= form_tag raif.admin_model_completion_batches_path, method: :get, class: "mb-4" do %>
+      <div class="row align-items-end">
+        <div class="col-md-3">
+          <div class="form-group">
+            <label for="status"><%= t("raif.admin.common.status") %></label>
+            <%= select_tag :status,
+                  options_for_select(
+                    [[t("raif.admin.common.all"), "all"]] +
+                      Raif::ModelCompletionBatch::STATUSES.map { |s| [s.titleize, s] },
+                    @selected_status
+                  ),
+                  { class: "form-select" } %>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-group">
+            <label for="llm_model_key"><%= t("raif.admin.common.model") %></label>
+            <%= select_tag :llm_model_key,
+                  options_for_select(
+                    [[t("raif.admin.common.all"), ""]] + @llm_model_keys.map { |key| [key, key] },
+                    @selected_llm_model_key
+                  ),
+                  { class: "form-select", data: { controller: "raif--tom-select" } } %>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="form-group">
+            <label for="type"><%= t("raif.admin.common.type") %></label>
+            <%= select_tag :type,
+                  options_for_select(
+                    [[t("raif.admin.common.all"), ""]] + @types.map { |t| [t, t] },
+                    @selected_type
+                  ),
+                  { class: "form-select", data: { controller: "raif--tom-select" } } %>
+          </div>
+        </div>
+        <div class="col-md-2">
+          <%= submit_tag t("raif.admin.common.filter"), class: "btn btn-primary" %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @model_completion_batches.any? %>
+      <div class="table-responsive">
+        <table class="table table-striped table-hover">
+          <thead class="table-light">
+            <tr>
+              <th><%= t("raif.admin.common.id") %></th>
+              <th><%= t("raif.admin.common.created_at") %></th>
+              <th><%= t("raif.admin.common.type") %></th>
+              <th><%= t("raif.admin.common.model") %></th>
+              <th><%= t("raif.admin.common.provider_batch_id") %></th>
+              <th><%= t("raif.admin.common.status") %></th>
+              <th><%= t("raif.admin.common.completions") %></th>
+              <th><%= t("raif.admin.common.submitted_at") %></th>
+              <th><%= t("raif.admin.common.ended_at") %></th>
+              <th><%= t("raif.admin.common.total_cost") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render partial: "raif/admin/model_completion_batches/model_completion_batch", collection: @model_completion_batches %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="mt-4">
+        <%= raif_pagy_nav(@pagy) %>
+      </div>
+    <% else %>
+      <div class="alert alert-info">
+        <%= t("raif.admin.common.no_model_completion_batches") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/raif/admin/model_completion_batches/index.html.erb
+++ b/app/views/raif/admin/model_completion_batches/index.html.erb
@@ -62,7 +62,7 @@
             </tr>
           </thead>
           <tbody>
-            <%= render partial: "raif/admin/model_completion_batches/model_completion_batch", collection: @model_completion_batches %>
+            <%= render partial: "raif/admin/model_completion_batches/model_completion_batch", collection: @model_completion_batches, locals: { completion_counts_by_batch_id: @completion_counts_by_batch_id } %>
           </tbody>
         </table>
       </div>

--- a/app/views/raif/admin/model_completion_batches/show.html.erb
+++ b/app/views/raif/admin/model_completion_batches/show.html.erb
@@ -1,0 +1,206 @@
+<div class="d-flex justify-content-between align-items-center my-4">
+  <h1><%= t(".title", id: @model_completion_batch.id) %></h1>
+  <%= link_to t(".back_to_model_completion_batches"), raif.admin_model_completion_batches_path, class: "btn btn-outline-secondary" %>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="mb-0"><%= t("raif.admin.common.details") %></h5>
+  </div>
+  <div class="card-body">
+    <div class="row">
+      <div class="col-md-6">
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.id") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.id %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.type") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.type %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.model") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.llm_model_key %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.model_api_name") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.model_api_name %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.provider_batch_id") %>:</strong></div>
+          <div class="col-7"><code><%= @model_completion_batch.provider_batch_id.presence || "-" %></code></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.creator") %>:</strong></div>
+          <div class="col-7">
+            <% if @model_completion_batch.creator.present? %>
+              <%= @model_completion_batch.creator.try(:raif_display_name) || "#{@model_completion_batch.creator_type} ##{@model_completion_batch.creator_id}" %>
+            <% else %>
+              -
+            <% end %>
+          </div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.status") %>:</strong></div>
+          <div class="col-7"><%= render "raif/admin/model_completion_batches/status_badge", model_completion_batch: @model_completion_batch %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.completion_handler") %>:</strong></div>
+          <div class="col-7"><code><%= @model_completion_batch.completion_handler_class_name.presence || "-" %></code></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.handler_dispatched_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.handler_dispatched_at&.rfc822 || "-" %></small></div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.created_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.created_at.rfc822 %></small></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.submitted_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.submitted_at&.rfc822 || "-" %></small></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.started_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.started_at&.rfc822 || "-" %></small></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.ended_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.ended_at&.rfc822 || "-" %></small></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.failed_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.failed_at&.rfc822 || "-" %></small></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.next_poll_at") %>:</strong></div>
+          <div class="col-7"><small><%= @model_completion_batch.next_poll_at&.rfc822 || "-" %></small></div>
+        </div>
+        <hr class="my-2">
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.prompt_token_cost") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.prompt_token_cost ? number_to_currency(@model_completion_batch.prompt_token_cost, precision: 6) : "-" %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.output_token_cost") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.output_token_cost ? number_to_currency(@model_completion_batch.output_token_cost, precision: 6) : "-" %></div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-5"><strong><%= t("raif.admin.common.total_cost") %>:</strong></div>
+          <div class="col-7"><%= @model_completion_batch.total_cost ? number_to_currency(@model_completion_batch.total_cost, precision: 6) : "-" %></div>
+        </div>
+      </div>
+    </div>
+
+    <% if @model_completion_batch.failure_reason.present? || @model_completion_batch.failure_error.present? %>
+      <hr>
+      <% if @model_completion_batch.failure_error.present? %>
+        <div class="row mb-2">
+          <div class="col-md-2"><strong><%= t("raif.admin.common.failure_error") %>:</strong></div>
+          <div class="col-md-10"><code><%= @model_completion_batch.failure_error %></code></div>
+        </div>
+      <% end %>
+      <% if @model_completion_batch.failure_reason.present? %>
+        <div class="row mb-2">
+          <div class="col-md-2"><strong><%= t("raif.admin.common.failure_reason") %>:</strong></div>
+          <div class="col-md-10"><%= @model_completion_batch.failure_reason %></div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<% if @model_completion_batch.request_counts.present? && @model_completion_batch.request_counts.any? %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h5 class="mb-0"><%= t("raif.admin.common.request_counts") %></h5>
+    </div>
+    <div class="card-body">
+      <pre class="pre-wrap mb-0"><%= JSON.pretty_generate(@model_completion_batch.request_counts) %></pre>
+    </div>
+  </div>
+<% end %>
+
+<% if @model_completion_batch.metadata.present? && @model_completion_batch.metadata.any? %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h5 class="mb-0"><%= t("raif.admin.common.metadata") %></h5>
+    </div>
+    <div class="card-body">
+      <pre class="pre-wrap mb-0"><%= JSON.pretty_generate(@model_completion_batch.metadata) %></pre>
+    </div>
+  </div>
+<% end %>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="mb-0"><%= t("raif.admin.common.model_completions") %> (<%= @model_completions.size %>)</h5>
+  </div>
+  <div class="card-body">
+    <% if @model_completions.any? %>
+      <div class="table-responsive">
+        <table class="table table-striped table-hover">
+          <thead class="table-light">
+            <tr>
+              <th><%= t("raif.admin.common.id") %></th>
+              <th><%= t("raif.admin.common.batch_custom_id") %></th>
+              <th><%= t("raif.admin.common.source") %></th>
+              <th><%= t("raif.admin.common.status") %></th>
+              <th><%= t("raif.admin.common.prompt_tokens") %></th>
+              <th><%= t("raif.admin.common.completion_tokens") %></th>
+              <th><%= t("raif.admin.common.total_tokens") %></th>
+              <th><%= t("raif.admin.common.total_cost") %></th>
+              <th><%= t("raif.admin.common.response") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @model_completions.each do |model_completion| %>
+              <tr>
+                <td><%= link_to "##{model_completion.id}", raif.admin_model_completion_path(model_completion) %></td>
+                <td><small><%= model_completion.batch_custom_id.presence || "-" %></small></td>
+                <td>
+                  <% if model_completion.source.present? %>
+                    <%= model_completion.source_type %> #<%= model_completion.source_id %>
+                  <% else %>
+                    -
+                  <% end %>
+                </td>
+                <td>
+                  <% if model_completion.failed? %>
+                    <span class="badge bg-danger"><%= t("raif.admin.common.failed") %></span>
+                  <% elsif model_completion.completed? %>
+                    <span class="badge bg-success"><%= t("raif.admin.common.completed") %></span>
+                  <% elsif model_completion.started? %>
+                    <span class="badge bg-warning text-dark"><%= t("raif.admin.common.in_progress") %></span>
+                  <% else %>
+                    <span class="badge bg-secondary"><%= t("raif.admin.common.pending") %></span>
+                  <% end %>
+                </td>
+                <td><%= model_completion.prompt_tokens ? number_with_delimiter(model_completion.prompt_tokens) : "-" %></td>
+                <td><%= model_completion.completion_tokens ? number_with_delimiter(model_completion.completion_tokens) : "-" %></td>
+                <td><%= model_completion.total_tokens ? number_with_delimiter(model_completion.total_tokens) : "-" %></td>
+                <td><%= model_completion.total_cost ? number_to_currency(model_completion.total_cost, precision: 6) : "-" %></td>
+                <td><small class="text-muted"><%= truncate(model_completion.raw_response.to_s, length: 80) %></small></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <p class="text-muted mb-0"><%= t("raif.admin.common.no_model_completions") %></p>
+    <% end %>
+  </div>
+</div>
+
+<% if @model_completion_batch.provider_response.present? && @model_completion_batch.provider_response.any? %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h5 class="mb-0"><%= t("raif.admin.common.provider_response") %></h5>
+    </div>
+    <div class="card-body">
+      <pre class="pre-wrap mb-0"><%= JSON.pretty_generate(@model_completion_batch.provider_response) %></pre>
+    </div>
+  </div>
+<% end %>

--- a/app/views/raif/admin/model_completions/show.html.erb
+++ b/app/views/raif/admin/model_completions/show.html.erb
@@ -44,6 +44,12 @@
           <div class="col-5"><strong><%= t("raif.admin.common.retry_count") %>:</strong></div>
           <div class="col-7"><%= @model_completion.retry_count %></div>
         </div>
+        <% if @model_completion.raif_model_completion_batch_id.present? %>
+          <div class="row mb-2">
+            <div class="col-5"><strong><%= t("raif.admin.common.batch") %>:</strong></div>
+            <div class="col-7"><%= link_to "##{@model_completion.raif_model_completion_batch_id}", raif.admin_model_completion_batch_path(@model_completion.raif_model_completion_batch_id) %></div>
+          </div>
+        <% end %>
       </div>
       <div class="col-md-6">
         <div class="row mb-2">

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -15,12 +15,16 @@ en:
         attempt: Attempt
         attempts: Attempts
         available_tools: Available Tools
+        batch: Batch
+        batch_custom_id: Batch Custom ID
         cache_creation_input_tokens: Cache Creation Tokens
         cache_read_input_tokens: Cache Read Tokens
         citations: Citations
         completed: Completed
         completed_at: Completed At
+        completion_handler: Completion Handler
         completion_tokens: Completion Tokens
+        completions: Completions
         config: Config
         conversation_entries: Conversation Entries
         conversation_history: Conversation History
@@ -32,6 +36,7 @@ en:
         description: Description
         details: Details
         duration: Duration
+        ended_at: Ended At
         entries_count: Entries Count
         entry: Entry
         est_cost: est. cost
@@ -42,6 +47,7 @@ en:
         failure_reason: Failure Reason
         filter: Filter
         final_answer: Final Answer
+        handler_dispatched_at: Handler Dispatched At
         id: ID
         in_progress: In Progress
         inferred_from_citations: Inferred from response citations.
@@ -55,14 +61,19 @@ en:
         latest_entry_at: Latest Entry At
         llms: LLMs
         messages: Messages
+        metadata: Metadata
         model: Model
+        model_api_name: Model API Name
         model_completion: Model Completion
+        model_completion_batches: Model Completion Batches
         model_completions: Model Completions
         model_response: Model Response
         model_tool_invocations: Model Tool Invocations
+        next_poll_at: Next Poll At
         no_agents: No agents found.
         no_citations: No citations found in this response.
         no_conversations: No conversations found.
+        no_model_completion_batches: No model completion batches found.
         no_model_completions: No model completions found.
         no_model_tool_invocations: No model tool invocations found.
         no_tasks: No tasks found.
@@ -77,11 +88,15 @@ en:
         period_week: Past week
         prettified: Prettified
         prompt: Prompt
+        prompt_token_cost: Prompt Token Cost
         prompt_tokens: Prompt Tokens
+        provider_batch_id: Provider Batch ID
         provider_managed_tool_calls: Provider-Managed Tool Calls
+        provider_response: Provider Response
         provider_tool_call_id: Provider Tool Call ID
         raw: Raw
         rendered: Rendered
+        request_counts: Request Counts
         requested_language: Requested Language
         response: Response
         response_array: Response Array
@@ -96,6 +111,7 @@ en:
         started_at: Started At
         stats: Stats
         status: Status
+        submitted_at: Submitted At
         system_prompt: System Prompt
         task: Task
         tasks: Tasks
@@ -144,6 +160,10 @@ en:
           provider: Provider
           search_placeholder: Search by name, provider, or API name...
           title: Registered LLMs
+      model_completion_batches:
+        show:
+          back_to_model_completion_batches: Back to Model Completion Batches
+          title: 'Model Completion Batch #%{id}'
       model_completions:
         show:
           back_to_model_completions: Back to Model Completions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Raif::Engine.routes.draw do
     resources :tasks, only: [:index, :show]
     resources :conversations, only: [:index, :show]
     resources :model_completions, only: [:index, :show]
+    resources :model_completion_batches, only: [:index, :show]
     resources :agents, only: [:index, :show]
     resources :model_tool_invocations, only: [:index, :show]
     resources :llms, only: [:index]

--- a/spec/features/raif/admin/model_completion_batches_spec.rb
+++ b/spec/features/raif/admin/model_completion_batches_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::ModelCompletionBatches", type: :feature do
+  let(:user) { FB.create(:raif_test_user) }
+
+  describe "index page" do
+    let!(:pending_batch) do
+      FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "pending",
+        creator: user
+      )
+    end
+
+    let!(:in_progress_batch) do
+      FB.create(
+        :raif_model_completion_batch_open_ai_responses,
+        status: "in_progress",
+        provider_batch_id: "batch_in_progress_123",
+        submitted_at: 1.hour.ago,
+        started_at: 30.minutes.ago,
+        creator: user
+      )
+    end
+
+    let!(:ended_batch) do
+      FB.create(
+        :raif_model_completion_batch_open_ai_responses,
+        status: "ended",
+        provider_batch_id: "batch_ended_456",
+        submitted_at: 2.hours.ago,
+        started_at: 90.minutes.ago,
+        ended_at: 30.minutes.ago,
+        total_cost: 0.123456,
+        creator: user
+      )
+    end
+
+    let!(:failed_batch) do
+      FB.create(
+        :raif_model_completion_batch_google,
+        status: "failed",
+        provider_batch_id: "batch_failed_789",
+        failed_at: 10.minutes.ago,
+        failure_reason: "Provider returned 500",
+        creator: user
+      )
+    end
+
+    it "lists all batches with key columns" do
+      visit raif.admin_model_completion_batches_path
+
+      expect(page).to have_content(I18n.t("raif.admin.common.model_completion_batches"))
+      expect(page).to have_css("tr.raif-model-completion-batch", count: 4)
+
+      expect(page).to have_content("Raif::ModelCompletionBatches::Anthropic")
+      expect(page).to have_content("Raif::ModelCompletionBatches::OpenAi")
+      expect(page).to have_content("Raif::ModelCompletionBatches::Google")
+
+      expect(page).to have_content("batch_in_progress_123")
+      expect(page).to have_content("batch_ended_456")
+      expect(page).to have_content("batch_failed_789")
+
+      expect(page).to have_content("$0.123456")
+
+      expect(page).to have_link("##{ended_batch.id}", href: raif.admin_model_completion_batch_path(ended_batch))
+    end
+
+    it "filters by status" do
+      visit raif.admin_model_completion_batches_path
+      expect(page).to have_css("tr.raif-model-completion-batch", count: 4)
+
+      select "Ended", from: "status"
+      click_button I18n.t("raif.admin.common.filter")
+
+      expect(page).to have_css("tr.raif-model-completion-batch", count: 1)
+      expect(page).to have_content("batch_ended_456")
+    end
+
+    it "filters by type" do
+      visit raif.admin_model_completion_batches_path
+
+      select "Raif::ModelCompletionBatches::Anthropic", from: "type"
+      click_button I18n.t("raif.admin.common.filter")
+
+      expect(page).to have_css("tr.raif-model-completion-batch", count: 1)
+      expect(page).to have_content("Raif::ModelCompletionBatches::Anthropic")
+    end
+
+    it "shows the empty state when there are no batches" do
+      Raif::ModelCompletionBatch.delete_all
+      visit raif.admin_model_completion_batches_path
+      expect(page).to have_content(I18n.t("raif.admin.common.no_model_completion_batches"))
+    end
+  end
+
+  describe "show page" do
+    let(:batch) do
+      FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "ended",
+        provider_batch_id: "batch_show_123",
+        submitted_at: 2.hours.ago,
+        started_at: 90.minutes.ago,
+        ended_at: 30.minutes.ago,
+        total_cost: 0.5,
+        prompt_token_cost: 0.3,
+        output_token_cost: 0.2,
+        completion_handler_class_name: "SomeHandler",
+        request_counts: { "completed" => 2, "failed" => 0 },
+        metadata: { "source" => "test" },
+        provider_response: { "results_url" => "https://example.com/results" },
+        creator: user
+      )
+    end
+
+    let!(:completion_one) do
+      Raif::ModelCompletion.create!(
+        raif_model_completion_batch: batch,
+        batch_custom_id: "item_1",
+        llm_model_key: "anthropic_claude_3_5_haiku",
+        model_api_name: "claude-3-5-haiku-latest",
+        response_format: "text",
+        raw_response: "First batch result",
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+        total_cost: 0.01,
+        completed_at: 1.hour.ago,
+        started_at: 90.minutes.ago
+      )
+    end
+
+    let!(:completion_two) do
+      Raif::ModelCompletion.create!(
+        raif_model_completion_batch: batch,
+        batch_custom_id: "item_2",
+        llm_model_key: "anthropic_claude_3_5_haiku",
+        model_api_name: "claude-3-5-haiku-latest",
+        response_format: "text",
+        raw_response: "Second batch result",
+        prompt_tokens: 80,
+        completion_tokens: 40,
+        total_tokens: 120,
+        total_cost: 0.008,
+        completed_at: 1.hour.ago,
+        started_at: 90.minutes.ago
+      )
+    end
+
+    it "displays batch details and its child completions" do
+      visit raif.admin_model_completion_batch_path(batch)
+
+      expect(page).to have_content(I18n.t("raif.admin.model_completion_batches.show.title", id: batch.id))
+
+      expect(page).to have_content("Raif::ModelCompletionBatches::Anthropic")
+      expect(page).to have_content("anthropic_claude_3_5_haiku")
+      expect(page).to have_content("claude-3-5-haiku-latest")
+      expect(page).to have_content("batch_show_123")
+      expect(page).to have_content("SomeHandler")
+
+      expect(page).to have_content("$0.500000")
+      expect(page).to have_content("$0.300000")
+      expect(page).to have_content("$0.200000")
+
+      expect(page).to have_content(I18n.t("raif.admin.common.request_counts"))
+      expect(page).to have_content('"completed": 2')
+
+      expect(page).to have_content(I18n.t("raif.admin.common.metadata"))
+      expect(page).to have_content('"source": "test"')
+
+      expect(page).to have_content(I18n.t("raif.admin.common.provider_response"))
+      expect(page).to have_content("https://example.com/results")
+
+      expect(page).to have_link("##{completion_one.id}", href: raif.admin_model_completion_path(completion_one))
+      expect(page).to have_link("##{completion_two.id}", href: raif.admin_model_completion_path(completion_two))
+      expect(page).to have_content("item_1")
+      expect(page).to have_content("item_2")
+      expect(page).to have_content("First batch result")
+      expect(page).to have_content("Second batch result")
+
+      click_link I18n.t("raif.admin.model_completion_batches.show.back_to_model_completion_batches")
+      expect(page).to have_current_path(raif.admin_model_completion_batches_path)
+    end
+
+    it "shows failure details when present" do
+      failed_batch = FB.create(
+        :raif_model_completion_batch_anthropic,
+        status: "failed",
+        failed_at: 5.minutes.ago,
+        failure_error: "ProviderError",
+        failure_reason: "Something went wrong"
+      )
+
+      visit raif.admin_model_completion_batch_path(failed_batch)
+
+      expect(page).to have_content("ProviderError")
+      expect(page).to have_content("Something went wrong")
+    end
+
+    it "shows no_model_completions when batch has no children" do
+      empty_batch = FB.create(:raif_model_completion_batch_anthropic)
+      visit raif.admin_model_completion_batch_path(empty_batch)
+      expect(page).to have_content(I18n.t("raif.admin.common.no_model_completions"))
+    end
+
+    it "links to the batch from the model_completion show page" do
+      visit raif.admin_model_completion_path(completion_one)
+      expect(page).to have_link("##{batch.id}", href: raif.admin_model_completion_batch_path(batch))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new admin section for `Raif::ModelCompletionBatch`, with an index (filters: status, llm_model_key, STI type) and a show page covering batch details, timestamps, costs, request counts, metadata, provider response, and a table of child `Raif::ModelCompletion` records linking back to their existing admin pages.
- Adds a sidebar nav entry between "Model Completions" and "Model Tool Invocations".
- Adds a "Batch" row on the `Raif::ModelCompletion` admin show page so you can jump from a completion to its parent batch.

## Test plan
- [ ] `bundle exec rspec spec/features/raif/admin/model_completion_batches_spec.rb` passes (8 examples)
- [ ] `bundle exec rspec spec/features/raif/admin/` passes (no regressions in the other admin features)
- [ ] Visit `/raif/admin/model_completion_batches` in the dummy app and confirm the listing, filters, and pagination behave
- [ ] Open a batch show page and confirm details, request_counts, metadata, provider_response, and child completions render
- [ ] From a model completion that belongs to a batch, confirm the new "Batch" link navigates to its batch show page
