### PR TITLE
Point google_gemini_3_1_flash_lite to GA api_name

### DIFF
--- a/lib/raif/llm_registry.rb
+++ b/lib/raif/llm_registry.rb
@@ -727,7 +727,7 @@ module Raif
         },
         {
           key: :google_gemini_3_1_flash_lite,
-          api_name: "gemini-3.1-flash-lite-preview",
+          api_name: "gemini-3.1-flash-lite",
           input_token_cost: 0.25 / 1_000_000,
           output_token_cost: 1.5 / 1_000_000,
           supported_provider_managed_tools: [


### PR DESCRIPTION
## Summary
- Google is discontinuing the `gemini-3.1-flash-lite-preview` model on 2026-05-25 and has moved Gemini 3.1 Flash Lite to GA.
- Updates the `:google_gemini_3_1_flash_lite` registry entry's `api_name` from `gemini-3.1-flash-lite-preview` to `gemini-3.1-flash-lite`. The registry key itself was already named for the GA model, so no downstream key changes are needed.
- Does not touch the `:open_router_gemini_3_1_flash_lite_preview` entry, which routes through OpenRouter and is on its own migration timeline.

## Test plan
- [ ] Confirm a Gemini 3.1 Flash Lite call via the Google adapter succeeds against the GA endpoint.
