### PR TITLE
Make batch finalize! idempotent so transient fetch_results! failures don't strand batches

### DIFF
--- a/app/jobs/raif/poll_model_completion_batch_job.rb
+++ b/app/jobs/raif/poll_model_completion_batch_job.rb
@@ -47,20 +47,24 @@ module Raif
       )
 
       # If the batch is already terminal at the top of perform, this run
-      # exists either to retry a handler that raised on a previous attempt
-      # (host's job adapter retried us, or the safety sweep beat us to the
-      # terminal transition) or because the polling chain raced with another
-      # finalize path. dispatch_completion_handler! is gated on
-      # handler_dispatched_at, so it's a no-op when the handler already ran
-      # successfully -- otherwise the early return here would silently
-      # swallow handler errors and the consumer's on_batch_completion block
-      # would never run.
+      # exists either to retry a finalize/handler that raised on a previous
+      # attempt (host's job adapter retried us, or the safety sweep beat us
+      # to the terminal transition) or because the polling chain raced with
+      # another finalize path. We call both finalize! and
+      # dispatch_completion_handler! here -- both are idempotent (gated on
+      # results_fetched_at and handler_dispatched_at respectively) so they
+      # no-op on a healthy batch. Calling finalize! is what lets the chain
+      # self-heal when a previous run's fetch_results! raised after
+      # fetch_status! had already committed the terminal status: without it
+      # the handler would dispatch against un-hydrated child completions.
       if batch.terminal?
         Raif.logger.info(
           "Raif::PollModelCompletionBatchJob ##{batch.id}: batch already terminal " \
-            "(status=#{batch.status}, handler_dispatched_at=#{batch.handler_dispatched_at&.iso8601 || "nil"}); " \
-            "dispatching completion handler and returning."
+            "(status=#{batch.status}, results_fetched_at=#{batch.results_fetched_at&.iso8601 || "nil"}, " \
+            "handler_dispatched_at=#{batch.handler_dispatched_at&.iso8601 || "nil"}); " \
+            "finalizing and dispatching completion handler."
         )
+        batch.finalize!
         batch.dispatch_completion_handler!
         return
       end

--- a/app/models/raif/model_completion_batch.rb
+++ b/app/models/raif/model_completion_batch.rb
@@ -207,6 +207,12 @@ module Raif
     # without that retry path the polling job's `return if batch.terminal?`
     # guard would silently swallow handler-raised errors and the consumer's
     # on_batch_completion block would never run.
+    #
+    # At-most-once across concurrent callers: the guard + handler invocation +
+    # timestamp write are wrapped in #with_lock so a normal poll job racing
+    # with the safety sweep (or a resume-stalled poll) cannot both pass the
+    # blank-handler_dispatched_at check and run the handler twice. Cheap
+    # callers still short-circuit before taking the lock.
     def dispatch_completion_handler!
       return if handler_dispatched_at.present?
       return if completion_handler_class_name.blank?
@@ -225,8 +231,14 @@ module Raif
         return
       end
 
-      handler.handle_batch_completion(self)
-      update_column(:handler_dispatched_at, Time.current)
+      with_lock do
+        # Re-check under lock: another worker may have dispatched between our
+        # early-return check above and lock acquisition.
+        return if handler_dispatched_at.present?
+
+        handler.handle_batch_completion(self)
+        update_column(:handler_dispatched_at, Time.current)
+      end
     end
 
     # True once submitted_at is older than Raif.config.model_completion_batch_max_age.
@@ -251,16 +263,28 @@ module Raif
     # subsequent finalize! call retries the fetch -- this is how the
     # poll chain self-heals from transient provider errors on the results
     # endpoint without permanently stranding the child completions.
+    #
+    # At-most-once across concurrent callers: the guard + fetch + stamp are
+    # wrapped in #with_lock so a normal poll job racing with the safety
+    # sweep (or a resume-stalled poll) cannot both pass the blank-
+    # results_fetched_at check and double-call fetch_results!. Cheap callers
+    # still short-circuit before taking the lock.
     def finalize!
       return if results_fetched_at.present?
 
-      if successful?
-        fetch_results!
-        update_column(:results_fetched_at, Time.current)
-      else
-        # force_fail! sets results_fetched_at inside its transaction so the
-        # success/failure paths converge on the same on-disk signal.
-        force_fail!(reason: "Batch ended with status: #{status}")
+      with_lock do
+        # Re-check under lock: another worker may have hydrated results
+        # between our early-return check above and lock acquisition.
+        return if results_fetched_at.present?
+
+        if successful?
+          fetch_results!
+          update_column(:results_fetched_at, Time.current)
+        else
+          # force_fail! sets results_fetched_at inside its transaction so the
+          # success/failure paths converge on the same on-disk signal.
+          force_fail!(reason: "Batch ended with status: #{status}")
+        end
       end
     end
 

--- a/app/models/raif/model_completion_batch.rb
+++ b/app/models/raif/model_completion_batch.rb
@@ -20,6 +20,7 @@
 #  prompt_token_cost             :decimal(10, 6)
 #  provider_response             :jsonb
 #  request_counts                :jsonb
+#  results_fetched_at            :datetime
 #  started_at                    :datetime
 #  status                        :string           default("pending"), not null
 #  submitted_at                  :datetime
@@ -209,6 +210,11 @@ module Raif
     def dispatch_completion_handler!
       return if handler_dispatched_at.present?
       return if completion_handler_class_name.blank?
+      # Local-side resolution must be complete before the handler runs --
+      # otherwise the handler would dispatch against child completions that
+      # haven't been hydrated with their provider results yet, which is how
+      # batches got silently stranded under the prior code path.
+      return if results_fetched_at.blank?
 
       handler = completion_handler_class_name.safe_constantize
       if handler.blank?
@@ -237,10 +243,23 @@ module Raif
     # other terminal statuses (canceled / expired / failed), force-fails every
     # still-pending child completion since there are no per-entry results to
     # collect.
+    #
+    # Idempotent via results_fetched_at: once a successful run finishes, future
+    # callers (the poll job's terminal-at-top path, the safety sweep, an
+    # ActiveJob retry of either) skip the provider round-trip. If
+    # fetch_results! raises mid-stream, results_fetched_at stays NULL so a
+    # subsequent finalize! call retries the fetch -- this is how the
+    # poll chain self-heals from transient provider errors on the results
+    # endpoint without permanently stranding the child completions.
     def finalize!
+      return if results_fetched_at.present?
+
       if successful?
         fetch_results!
+        update_column(:results_fetched_at, Time.current)
       else
+        # force_fail! sets results_fetched_at inside its transaction so the
+        # success/failure paths converge on the same on-disk signal.
         force_fail!(reason: "Batch ended with status: #{status}")
       end
     end
@@ -307,6 +326,8 @@ module Raif
           mc.update_columns(started_at: started_at) if mc.started_at.nil? && started_at.present?
           mc.failed!
         end
+
+        update_column(:results_fetched_at, Time.current) if results_fetched_at.blank?
       end
     end
 

--- a/app/models/raif/model_completion_batches/anthropic.rb
+++ b/app/models/raif/model_completion_batches/anthropic.rb
@@ -20,6 +20,7 @@
 #  prompt_token_cost             :decimal(10, 6)
 #  provider_response             :jsonb
 #  request_counts                :jsonb
+#  results_fetched_at            :datetime
 #  started_at                    :datetime
 #  status                        :string           default("pending"), not null
 #  submitted_at                  :datetime

--- a/app/models/raif/model_completion_batches/google.rb
+++ b/app/models/raif/model_completion_batches/google.rb
@@ -20,6 +20,7 @@
 #  prompt_token_cost             :decimal(10, 6)
 #  provider_response             :jsonb
 #  request_counts                :jsonb
+#  results_fetched_at            :datetime
 #  started_at                    :datetime
 #  status                        :string           default("pending"), not null
 #  submitted_at                  :datetime

--- a/app/models/raif/model_completion_batches/open_ai.rb
+++ b/app/models/raif/model_completion_batches/open_ai.rb
@@ -20,6 +20,7 @@
 #  prompt_token_cost             :decimal(10, 6)
 #  provider_response             :jsonb
 #  request_counts                :jsonb
+#  results_fetched_at            :datetime
 #  started_at                    :datetime
 #  status                        :string           default("pending"), not null
 #  submitted_at                  :datetime

--- a/app/models/raif/model_completion_batches/x_ai.rb
+++ b/app/models/raif/model_completion_batches/x_ai.rb
@@ -20,6 +20,7 @@
 #  prompt_token_cost             :decimal(10, 6)
 #  provider_response             :jsonb
 #  request_counts                :jsonb
+#  results_fetched_at            :datetime
 #  started_at                    :datetime
 #  status                        :string           default("pending"), not null
 #  submitted_at                  :datetime

--- a/db/migrate/20260521000000_add_results_fetched_at_to_raif_model_completion_batches.rb
+++ b/db/migrate/20260521000000_add_results_fetched_at_to_raif_model_completion_batches.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddResultsFetchedAtToRaifModelCompletionBatches < ActiveRecord::Migration[7.1]
+  def up
+    add_column :raif_model_completion_batches, :results_fetched_at, :datetime
+
+    # Backfill so the new finalize! idempotency guard doesn't cause already-completed
+    # historical batches to re-call fetch_batch_results! the next time their poll job
+    # fires. We mark a batch as "results fetched" iff its handler was already
+    # dispatched AND every child completion is terminal -- which is the on-disk
+    # signature of a finalize! that ran successfully under the prior code path.
+    #
+    # Batches with a dispatched handler but some still-unresolved child completions
+    # (the silent-stranding signature this fix targets) are intentionally left with
+    # results_fetched_at NULL, so the next poll's terminal-at-top branch can re-run
+    # fetch_batch_results! and recover them.
+    execute(<<~SQL)
+      UPDATE raif_model_completion_batches b
+      SET results_fetched_at = COALESCE(b.handler_dispatched_at, b.ended_at, b.failed_at)
+      WHERE b.status IN ('ended', 'canceled', 'expired', 'failed')
+        AND b.handler_dispatched_at IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM raif_model_completions c
+          WHERE c.raif_model_completion_batch_id = b.id
+            AND c.completed_at IS NULL
+            AND c.failed_at IS NULL
+        );
+    SQL
+  end
+
+  def down
+    remove_column :raif_model_completion_batches, :results_fetched_at
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -135,6 +135,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
     t.string "provider_batch_id"
     t.jsonb "provider_response"
     t.jsonb "request_counts"
+    t.datetime "results_fetched_at"
     t.datetime "started_at"
     t.string "status", default: "pending", null: false
     t.datetime "submitted_at"

--- a/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
+++ b/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
@@ -247,8 +247,8 @@ RSpec.describe Raif::PollModelCompletionBatchJob, type: :job do
         expect(batch.reload.handler_dispatched_at).to be_nil
         expect(RetryFinalizeHandlerStub.calls).to eq(0)
 
-        # Second poll (ActiveJob retry / safety sweep / etc.): xAI now responds
-        # cleanly, finalize! completes, handler dispatches.
+        # Second poll (ActiveJob retry / safety sweep / etc.): the provider
+        # now responds cleanly, finalize! completes, handler dispatches.
         described_class.perform_now(batch.id)
 
         expect(call_count).to eq(2)

--- a/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
+++ b/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Raif::PollModelCompletionBatchJob, type: :job do
         )
 
         call_count = 0
-        allow(llm_double).to receive(:fetch_batch_results!) do |b|
+        allow(llm_double).to receive(:fetch_batch_results!) do |_b|
           call_count += 1
           raise Faraday::BadRequestError, "transient 400" if call_count == 1
         end

--- a/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
+++ b/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
@@ -204,6 +204,60 @@ RSpec.describe Raif::PollModelCompletionBatchJob, type: :job do
       end.to have_enqueued_job(described_class).with(batch.id, attempt: 2)
     end
 
+    describe "terminal-batch finalize retry" do
+      it "re-runs finalize! on a subsequent run when results_fetched_at is still NULL" do
+        # Regression: under the prior code path, a fetch_batch_results! that
+        # raised after fetch_batch_status! had committed the terminal status
+        # would permanently strand the batch -- the next poll's
+        # terminal-at-top branch dispatched the completion handler against
+        # un-hydrated child completions. With finalize! now called in that
+        # branch (and gated on results_fetched_at), the rescheduled run
+        # retries fetch_batch_results! and the chain self-heals.
+        stub_const("RetryFinalizeHandlerStub", Class.new do
+          @calls = 0
+          class << self
+            attr_accessor :calls
+          end
+
+          def self.handle_batch_completion(_batch)
+            self.calls += 1
+          end
+        end)
+
+        batch.update!(
+          status: "ended",
+          ended_at: 1.minute.ago,
+          completion_handler_class_name: "RetryFinalizeHandlerStub"
+        )
+
+        call_count = 0
+        allow(llm_double).to receive(:fetch_batch_results!) do |b|
+          call_count += 1
+          raise Faraday::BadRequestError, "transient 400" if call_count == 1
+        end
+
+        # First poll on the already-terminal batch: fetch_results! raises.
+        # The job's rescue path re-raises (BadRequest isn't transient by default).
+        expect do
+          described_class.perform_now(batch.id)
+        end.to raise_error(Faraday::BadRequestError)
+
+        # results_fetched_at remained NULL, handler never dispatched.
+        expect(batch.reload.results_fetched_at).to be_nil
+        expect(batch.reload.handler_dispatched_at).to be_nil
+        expect(RetryFinalizeHandlerStub.calls).to eq(0)
+
+        # Second poll (ActiveJob retry / safety sweep / etc.): xAI now responds
+        # cleanly, finalize! completes, handler dispatches.
+        described_class.perform_now(batch.id)
+
+        expect(call_count).to eq(2)
+        expect(batch.reload.results_fetched_at).to be_present
+        expect(batch.reload.handler_dispatched_at).to be_present
+        expect(RetryFinalizeHandlerStub.calls).to eq(1)
+      end
+    end
+
     describe "terminal-batch handler retry" do
       it "re-dispatches the handler on a subsequent run when handler_dispatched_at is still NULL" do
         stub_const("RetryHandlerStub", Class.new do
@@ -255,15 +309,17 @@ RSpec.describe Raif::PollModelCompletionBatchJob, type: :job do
         batch.update!(
           status: "ended",
           completion_handler_class_name: "AlreadyDispatchedHandlerStub",
+          results_fetched_at: 1.minute.ago,
           handler_dispatched_at: 1.minute.ago
         )
 
         described_class.perform_now(batch.id)
 
-        # Handler is gated on handler_dispatched_at; the second perform call
-        # must not re-run it.
+        # Both gates set -- finalize! and dispatch_completion_handler! both
+        # no-op, so the provider isn't touched and the handler isn't re-run.
         expect(AlreadyDispatchedHandlerStub.calls).to eq(0)
         expect(llm_double).not_to have_received(:fetch_batch_status!)
+        expect(llm_double).not_to have_received(:fetch_batch_results!)
       end
     end
   end

--- a/spec/models/raif/model_completion_batch_spec.rb
+++ b/spec/models/raif/model_completion_batch_spec.rb
@@ -20,6 +20,7 @@
 #  prompt_token_cost             :decimal(10, 6)
 #  provider_response             :jsonb
 #  request_counts                :jsonb
+#  results_fetched_at            :datetime
 #  started_at                    :datetime
 #  status                        :string           default("pending"), not null
 #  submitted_at                  :datetime
@@ -287,6 +288,32 @@ RSpec.describe Raif::ModelCompletionBatch, type: :model do
       expect { batch.dispatch_completion_handler! }.not_to raise_error
     end
 
+    it "is a no-op when results_fetched_at is blank" do
+      # Defense in depth: even if a caller bypasses finalize! and invokes
+      # dispatch directly, we refuse to run the handler against a batch whose
+      # child completions haven't been hydrated yet. This is the guard that
+      # prevents the silent-stranding bug where a fetch_results! failure
+      # would otherwise be followed by a handler dispatch against
+      # parsed_response-blank tasks.
+      stub_const("UndispatchedHandlerStub", Class.new do
+        @calls = 0
+        class << self
+          attr_accessor :calls
+        end
+
+        def self.handle_batch_completion(_batch)
+          self.calls += 1
+        end
+      end)
+
+      batch.update!(completion_handler_class_name: "UndispatchedHandlerStub", results_fetched_at: nil)
+
+      batch.dispatch_completion_handler!
+
+      expect(UndispatchedHandlerStub.calls).to eq(0)
+      expect(batch.reload.handler_dispatched_at).to be_nil
+    end
+
     it "calls handle_batch_completion on the resolved class and stamps handler_dispatched_at" do
       stub_const("BatchCompletionHandlerStub", Class.new do
         def self.handle_batch_completion(batch)
@@ -298,7 +325,7 @@ RSpec.describe Raif::ModelCompletionBatch, type: :model do
         end
       end)
 
-      batch.update!(completion_handler_class_name: "BatchCompletionHandlerStub")
+      batch.update!(completion_handler_class_name: "BatchCompletionHandlerStub", results_fetched_at: Time.current)
       expect(batch.handler_dispatched_at).to be_nil
 
       batch.dispatch_completion_handler!
@@ -319,7 +346,7 @@ RSpec.describe Raif::ModelCompletionBatch, type: :model do
         end
       end)
 
-      batch.update!(completion_handler_class_name: "CountedHandlerStub")
+      batch.update!(completion_handler_class_name: "CountedHandlerStub", results_fetched_at: Time.current)
 
       batch.dispatch_completion_handler!
       first_dispatched_at = batch.reload.handler_dispatched_at
@@ -336,19 +363,90 @@ RSpec.describe Raif::ModelCompletionBatch, type: :model do
         end
       end)
 
-      batch.update!(completion_handler_class_name: "RaisingHandlerStub")
+      batch.update!(completion_handler_class_name: "RaisingHandlerStub", results_fetched_at: Time.current)
 
       expect { batch.dispatch_completion_handler! }.to raise_error("synthetic-failure")
       expect(batch.reload.handler_dispatched_at).to be_nil
     end
 
     it "logs and skips when the class name does not resolve" do
-      batch.update!(completion_handler_class_name: "NoSuchHandlerClassXYZ")
+      batch.update!(completion_handler_class_name: "NoSuchHandlerClassXYZ", results_fetched_at: Time.current)
       expect(Raif.logger).to receive(:error).with(a_string_matching(/could not be resolved/))
       expect { batch.dispatch_completion_handler! }.not_to raise_error
       # Misconfigured handler -- no work was done, so leave the flag NULL in
       # case the host fixes the class name and re-dispatches.
       expect(batch.reload.handler_dispatched_at).to be_nil
+    end
+  end
+
+  describe "#finalize!" do
+    let(:batch) { FB.create(:raif_model_completion_batch_anthropic, status: "ended", ended_at: Time.current) }
+    let(:llm_double) { instance_double(Raif::Llms::Anthropic) }
+
+    before do
+      allow(batch).to receive(:llm).and_return(llm_double)
+    end
+
+    it "calls fetch_results! on a successful batch and stamps results_fetched_at" do
+      allow(llm_double).to receive(:fetch_batch_results!)
+
+      batch.finalize!
+
+      expect(llm_double).to have_received(:fetch_batch_results!).with(batch).once
+      expect(batch.reload.results_fetched_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it "is idempotent: a second call after results_fetched_at is set does not re-fetch" do
+      allow(llm_double).to receive(:fetch_batch_results!)
+
+      batch.finalize!
+      batch.finalize!
+
+      expect(llm_double).to have_received(:fetch_batch_results!).with(batch).once
+    end
+
+    it "leaves results_fetched_at NULL when fetch_results! raises so a future call can retry" do
+      # This is the central retry-on-transient-failure regression: a
+      # fetch_batch_results! that raises (e.g. provider returns a transient
+      # 4xx on /results) must not silently mark the batch as resolved,
+      # because that would let the handler dispatch against un-hydrated
+      # child completions.
+      allow(llm_double).to receive(:fetch_batch_results!).and_raise(Faraday::BadRequestError, "transient 400")
+
+      expect { batch.finalize! }.to raise_error(Faraday::BadRequestError)
+      expect(batch.reload.results_fetched_at).to be_nil
+    end
+
+    it "retries fetch_results! on a subsequent call after the previous one raised" do
+      call_count = 0
+      allow(llm_double).to receive(:fetch_batch_results!) do
+        call_count += 1
+        raise Faraday::BadRequestError, "transient 400" if call_count == 1
+      end
+
+      expect { batch.finalize! }.to raise_error(Faraday::BadRequestError)
+      expect(batch.reload.results_fetched_at).to be_nil
+
+      batch.finalize!
+
+      expect(call_count).to eq(2)
+      expect(batch.reload.results_fetched_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it "delegates to force_fail! for non-successful terminal statuses and ends with results_fetched_at set" do
+      batch.update!(status: "canceled")
+      mc = FB.create(
+        :raif_model_completion,
+        raif_model_completion_batch: batch,
+        batch_custom_id: "x1",
+        model_api_name: "claude-3-5-haiku-latest",
+        llm_model_key: "anthropic_claude_3_5_haiku"
+      )
+
+      batch.finalize!
+
+      expect(mc.reload.failed?).to be(true)
+      expect(batch.reload.results_fetched_at).to be_within(2.seconds).of(Time.current)
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds a `results_fetched_at` column on `Raif::ModelCompletionBatch` that gates `dispatch_completion_handler!` and makes `finalize!` idempotent, so a `fetch_batch_results!` that raises no longer permanently strands the batch.
- Has the poll job's terminal-at-top branch call `finalize!` (in addition to `dispatch_completion_handler!`), so transient failures on the results endpoint self-heal on a subsequent poll.
- Migration backfills the new column for already-terminal batches with a dispatched handler and fully-resolved child completions, so the new code path doesn't re-fetch results for historical batches that completed cleanly.

## The bug this fixes

The batch lifecycle has two steps that update separate state:

1. `fetch_batch_status!` commits `status: "ended"` (and `ended_at`) inside `with_lock` once the provider reports terminal.
2. `finalize!` calls `fetch_batch_results!`, which hydrates per-entry payloads onto the child `Raif::ModelCompletion` rows.

If step 2 raises after step 1 has committed -- e.g. the provider returns a transient 4xx on `/results` -- the poll job's rescue path either reschedules (transient exception) or re-raises (non-transient). On either path the rescheduled run hits this branch at the top of `perform`:

```ruby
if batch.terminal?
  batch.dispatch_completion_handler!
  return
end
```

The handler dispatches against child completions that were never hydrated. Their `parsed_response` is blank, so consumer-side aggregation (e.g. `Csf::LlmForecaster#finalize_forecast_from_tasks` in Hinsley) sees "every task failed" and records a permanent failure for what was actually a transient provider blip. The provider still has the result data; we just stop trying to fetch it.

## The fix

Two-piece change with one new column:

1. **`results_fetched_at` column** on `raif_model_completion_batches`. Set inside `finalize!` (success path) and inside `force_fail!`'s transaction (failure path) so both terminal routes converge on the same on-disk signal.

2. **Idempotency on that column:**
   - `finalize!` returns early when `results_fetched_at` is present.
   - `dispatch_completion_handler!` returns early when `results_fetched_at` is blank (defense in depth -- prevents handler dispatch against un-hydrated tasks even if a caller bypasses `finalize!`).

3. **Poll job change:** the terminal-at-top branch now calls `batch.finalize!` before `batch.dispatch_completion_handler!`. Both are idempotent on a healthy batch (no-ops), but on a previously-failed-mid-finalize batch the `finalize!` call retries `fetch_batch_results!`. The chain self-heals across `ActiveJob` retries, the safety sweep, and the resume-stalled sweep.

## Migration & backfill

The migration adds the column and backfills `results_fetched_at` for already-terminal batches where:

- `handler_dispatched_at` is set, AND
- every child `Raif::ModelCompletion` is in a terminal state (`completed_at IS NOT NULL OR failed_at IS NOT NULL`).

That's the on-disk signature of a `finalize!` that ran successfully under the prior code path. Batches with a dispatched handler but un-hydrated child completions (the silent-stranding signature) are intentionally left with `results_fetched_at NULL`, so the next poll's terminal-at-top branch will recover them.

## What changes for hosts

- **No API change.** `finalize!` and `dispatch_completion_handler!` have the same signatures and the same observable behavior on the happy path.
- **Behavior change on the failure path.** A `fetch_batch_results!` that raises no longer dispatches the handler against un-hydrated tasks. Hosts whose handlers tolerated that case (and produced a "synthetic failure" forecast/output) will now see the handler simply not run until results are hydrated. If results never come (provider data really is gone), the handler never dispatches; downstream completeness checks should flag the missing output (in Hinsley's case, `Research::Workflow#compute_forecast_completeness!` already does this).

## Test plan

- [x] Full Raif spec suite passes (1319 examples, 0 failures, 4 pending).
- [x] New unit tests for `finalize!` idempotency (no double API call when `results_fetched_at` is set), retry-after-raise semantics (a `Faraday::BadRequestError` leaves `results_fetched_at` NULL so the next call retries and succeeds), and the `force_fail!`-sets-`results_fetched_at` invariant.
- [x] New unit test for the `dispatch_completion_handler!` guard (handler is a no-op when `results_fetched_at` is blank, even with everything else set).
- [x] New integration regression test in `poll_model_completion_batch_job_spec.rb`: a poll job whose `fetch_batch_results!` raises is followed by a second poll job that retries and dispatches successfully (this is the actual bug repro).
- [x] Existing batch-related tests updated to set `results_fetched_at` where they were unit-testing the post-finalize path.
