### PR TITLE
Add subject (polymorphic) and config (jsonb) to Raif::Conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.6.0-pre
 
+- Added optional `subject` (polymorphic) and `config` (jsonb, default `{}`) columns to `Raif::Conversation` for host apps that want to attach a domain object and/or arbitrary configuration to a conversation.
 - Added an xAI adapter (`Raif::Llms::XAi`) with support for streaming, developer-managed tools, and native [structured outputs](https://docs.x.ai/developers/model-capabilities/text/structured-outputs) via `response_format: { type: "json_schema" }` on `/v1/chat/completions`. Registered Grok models: `x_ai_grok_4_3`, `x_ai_grok_4_20_reasoning`, and `x_ai_grok_4_20_non_reasoning`. Configure via `Raif.config.x_ai_api_key` / `Raif.config.x_ai_models_enabled` (or `ENV["XAI_API_KEY"]`).
 - Added xAI [Batch API](https://docs.x.ai/docs/guides/batch) support.
 - Added a tool-call repair loop to `Raif::ConversationEntry`. When a tool call is malformed (unknown tool name, non-hash arguments, schema mismatch, `prepare_tool_arguments` raises), Raif re-prompts the model with synthetic user-role corrective feedback up to `Raif.config.conversation_entry_max_retries` times (default: 2) before marking the entry as failed. Each attempt produces a new `Raif::ModelCompletion` attached to the same entry and is visible in the web admin.

--- a/app/models/raif/conversation.rb
+++ b/app/models/raif/conversation.rb
@@ -7,6 +7,7 @@
 #  id                         :bigint           not null, primary key
 #  available_model_tools      :jsonb            not null
 #  available_user_tools       :jsonb            not null
+#  config                     :jsonb            not null
 #  conversation_entries_count :integer          default(0), not null
 #  creator_type               :string           not null
 #  generating_entry_response  :boolean          default(FALSE), not null
@@ -16,18 +17,21 @@
 #  requested_language_key     :string
 #  response_format            :integer          default("text"), not null
 #  source_type                :string
+#  subject_type               :string
 #  system_prompt              :text
 #  type                       :string           not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  creator_id                 :bigint           not null
 #  source_id                  :bigint
+#  subject_id                 :bigint
 #
 # Indexes
 #
 #  index_raif_conversations_on_created_at  (created_at)
 #  index_raif_conversations_on_creator     (creator_type,creator_id)
 #  index_raif_conversations_on_source      (source_type,source_id)
+#  index_raif_conversations_on_subject     (subject_type,subject_id)
 #
 class Raif::Conversation < Raif::ApplicationRecord
   prepend Raif::Concerns::HasPromptTemplates
@@ -40,6 +44,7 @@ class Raif::Conversation < Raif::ApplicationRecord
 
   belongs_to :creator, polymorphic: true
   belongs_to :source, polymorphic: true, optional: true
+  belongs_to :subject, polymorphic: true, optional: true
 
   class << self
     def before_prompt_model_for_entry_response(&block)
@@ -68,6 +73,7 @@ class Raif::Conversation < Raif::ApplicationRecord
   after_initialize -> { self.available_model_tools ||= [] }
   after_initialize -> { self.available_user_tools ||= [] }
   after_initialize -> { self.llm_messages_max_length ||= Raif.config.conversation_llm_messages_max_length_default }
+  after_initialize -> { self.config ||= {} }
 
   before_validation ->{ self.type ||= "Raif::Conversation" }, on: :create
 

--- a/db/migrate/20260521195606_add_subject_and_config_to_raif_conversations.rb
+++ b/db/migrate/20260521195606_add_subject_and_config_to_raif_conversations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSubjectAndConfigToRaifConversations < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :raif_conversations, :subject, polymorphic: true, index: true
+    add_column :raif_conversations, :config, :jsonb, null: false, default: {}
+  end
+end

--- a/db/migrate/20260521195606_add_subject_and_config_to_raif_conversations.rb
+++ b/db/migrate/20260521195606_add_subject_and_config_to_raif_conversations.rb
@@ -2,7 +2,13 @@
 
 class AddSubjectAndConfigToRaifConversations < ActiveRecord::Migration[7.1]
   def change
+    json_column_type = if connection.adapter_name.downcase.include?("postgresql")
+      :jsonb
+    else
+      :json
+    end
+
     add_reference :raif_conversations, :subject, polymorphic: true, index: true
-    add_column :raif_conversations, :config, :jsonb, null: false, default: {}
+    add_column :raif_conversations, :config, json_column_type, null: false
   end
 end

--- a/db/migrate/20260521195606_add_subject_and_config_to_raif_conversations.rb
+++ b/db/migrate/20260521195606_add_subject_and_config_to_raif_conversations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSubjectAndConfigToRaifConversations < ActiveRecord::Migration[8.1]
+class AddSubjectAndConfigToRaifConversations < ActiveRecord::Migration[7.1]
   def change
     add_reference :raif_conversations, :subject, polymorphic: true, index: true
     add_column :raif_conversations, :config, :jsonb, null: false, default: {}

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -96,7 +96,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_21_195606) do
   create_table "raif_conversations", force: :cascade do |t|
     t.jsonb "available_model_tools", null: false
     t.jsonb "available_user_tools", null: false
-    t.jsonb "config", default: {}, null: false
+    t.jsonb "config", null: false
     t.integer "conversation_entries_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.bigint "creator_id", null: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_21_195606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
   create_table "raif_conversations", force: :cascade do |t|
     t.jsonb "available_model_tools", null: false
     t.jsonb "available_user_tools", null: false
+    t.jsonb "config", default: {}, null: false
     t.integer "conversation_entries_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.bigint "creator_id", null: false
@@ -108,12 +109,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
     t.integer "response_format", default: 0, null: false
     t.bigint "source_id"
     t.string "source_type"
+    t.bigint "subject_id"
+    t.string "subject_type"
     t.text "system_prompt"
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_raif_conversations_on_created_at"
     t.index ["creator_type", "creator_id"], name: "index_raif_conversations_on_creator"
     t.index ["source_type", "source_id"], name: "index_raif_conversations_on_source"
+    t.index ["subject_type", "subject_id"], name: "index_raif_conversations_on_subject"
   end
 
   create_table "raif_model_completion_batches", force: :cascade do |t|
@@ -135,6 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_000000) do
     t.string "provider_batch_id"
     t.jsonb "provider_response"
     t.jsonb "request_counts"
+    t.datetime "results_fetched_at"
     t.datetime "started_at"
     t.string "status", default: "pending", null: false
     t.datetime "submitted_at"

--- a/spec/models/raif/conversation_spec.rb
+++ b/spec/models/raif/conversation_spec.rb
@@ -7,6 +7,7 @@
 #  id                         :bigint           not null, primary key
 #  available_model_tools      :jsonb            not null
 #  available_user_tools       :jsonb            not null
+#  config                     :jsonb            not null
 #  conversation_entries_count :integer          default(0), not null
 #  creator_type               :string           not null
 #  generating_entry_response  :boolean          default(FALSE), not null
@@ -16,18 +17,21 @@
 #  requested_language_key     :string
 #  response_format            :integer          default("text"), not null
 #  source_type                :string
+#  subject_type               :string
 #  system_prompt              :text
 #  type                       :string           not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  creator_id                 :bigint           not null
 #  source_id                  :bigint
+#  subject_id                 :bigint
 #
 # Indexes
 #
 #  index_raif_conversations_on_created_at  (created_at)
 #  index_raif_conversations_on_creator     (creator_type,creator_id)
 #  index_raif_conversations_on_source      (source_type,source_id)
+#  index_raif_conversations_on_subject     (subject_type,subject_id)
 #
 require "rails_helper"
 
@@ -49,6 +53,36 @@ RSpec.describe Raif::Conversation, type: :model do
 
       expect(conversation.source).to be_nil
       expect(conversation).to be_valid
+    end
+
+    it "belongs to a polymorphic subject" do
+      subject_record = Raif::TestUser.create!(email: "subject@example.com")
+      conversation = FB.create(:raif_conversation, creator: creator, subject: subject_record)
+
+      expect(conversation.subject).to eq(subject_record)
+      expect(conversation.subject_type).to eq("Raif::TestUser")
+      expect(conversation.subject_id).to eq(subject_record.id)
+    end
+
+    it "allows subject to be nil" do
+      conversation = FB.create(:raif_conversation, creator: creator, subject: nil)
+
+      expect(conversation.subject).to be_nil
+      expect(conversation).to be_valid
+    end
+  end
+
+  describe "config" do
+    it "defaults to an empty hash" do
+      conversation = FB.build(:raif_conversation, creator: creator)
+      expect(conversation.config).to eq({})
+    end
+
+    it "persists arbitrary keys and values" do
+      conversation = FB.create(:raif_conversation, creator: creator, config: { "foo" => "bar", "n" => 3 })
+      conversation.reload
+
+      expect(conversation.config).to eq({ "foo" => "bar", "n" => 3 })
     end
   end
 


### PR DESCRIPTION
Gives every conversation a canonical place to record the artifact it
references (subject) and per-type behavioral knobs (config), without
the engine needing to know any host-app domain. Hosts wire validation
and param coercion in their conversation subclasses; Raif just provides
the storage.
