### PR TITLE
Don't notify Airbrake for transient errors in PollModelCompletionBatchJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.6.0-pre
 
+- `Raif::PollModelCompletionBatchJob` no longer notifies the host's error tracker (Airbrake) for transient provider errors. The job already reschedules itself on the exception classes listed in `Raif.config.llm_request_retriable_exceptions` (e.g. `Faraday::ServerError` for upstream 5xx, `Faraday::TimeoutError`, `Faraday::ConnectionFailed`), so per-attempt notifications were noise that didn't correspond to actionable work. Transient errors are still logged at `error` level; non-transient errors are notified and re-raised as before.
 - Added optional `subject` (polymorphic) and `config` (jsonb, default `{}`) columns to `Raif::Conversation` for host apps that want to attach a domain object and/or arbitrary configuration to a conversation.
 - Added an xAI adapter (`Raif::Llms::XAi`) with support for streaming, developer-managed tools, and native [structured outputs](https://docs.x.ai/developers/model-capabilities/text/structured-outputs) via `response_format: { type: "json_schema" }` on `/v1/chat/completions`. Registered Grok models: `x_ai_grok_4_3`, `x_ai_grok_4_20_reasoning`, and `x_ai_grok_4_20_non_reasoning`. Configure via `Raif.config.x_ai_api_key` / `Raif.config.x_ai_models_enabled` (or `ENV["XAI_API_KEY"]`).
 - Added xAI [Batch API](https://docs.x.ai/docs/guides/batch) support.

--- a/app/jobs/raif/poll_model_completion_batch_job.rb
+++ b/app/jobs/raif/poll_model_completion_batch_job.rb
@@ -20,11 +20,12 @@ module Raif
   #    force-failed and the handler is dispatched.
   #
   # On a transient error from the provider (the exception classes listed in
-  # Raif.config.llm_request_retriable_exceptions), the job logs + notifies
-  # but reschedules itself instead of re-raising, so the chain self-heals
-  # across the kinds of failures that ActiveJob retry policies typically
-  # cover. Non-transient errors are re-raised so the host's job adapter
-  # surfaces them.
+  # Raif.config.llm_request_retriable_exceptions), the job logs and
+  # reschedules itself instead of re-raising or notifying the host's error
+  # tracker, so the chain self-heals across the kinds of failures that
+  # ActiveJob retry policies typically cover without producing per-attempt
+  # noise. Non-transient errors are notified (Airbrake, if loaded) and
+  # re-raised so the host's job adapter surfaces them.
   #
   # The self-reschedule uses `perform_later(wait: ...)`, so the configured
   # ActiveJob queue adapter must support scheduled jobs. If the host app's
@@ -98,9 +99,14 @@ module Raif
 
       reschedule!(batch, attempt: attempt)
     rescue StandardError => e
-      log_and_notify_error(batch_id, e)
+      log_error(batch_id, e)
 
       if transient_error?(e)
+        # Transient errors self-heal via reschedule (or are no-ops if another
+        # process already finalized the batch), so we don't notify the host's
+        # error tracker for them -- otherwise every flaky provider response
+        # produces noise that doesn't correspond to actionable work.
+        #
         # Reload (the batch may have been transitioned by another process while
         # we were in flight). Three cases after reload:
         # 1. Batch missing -> nothing to reschedule against, end of chain.
@@ -126,6 +132,7 @@ module Raif
         return
       end
 
+      notify_error(batch_id, e)
       raise
     end
 
@@ -154,16 +161,18 @@ module Raif
       retriable.any? { |klass| error.is_a?(klass) }
     end
 
-    def log_and_notify_error(batch_id, error)
+    def log_error(batch_id, error)
       Raif.logger.error("Raif::PollModelCompletionBatchJob ##{batch_id} failed: #{error.class}: #{error.message}")
       Raif.logger.error(error.backtrace.first(20).join("\n")) if error.backtrace.present?
+    end
 
-      if defined?(Airbrake)
-        notice = Airbrake.build_notice(error)
-        notice[:context][:component] = "raif_poll_model_completion_batch_job"
-        notice[:params] = { batch_id: batch_id }
-        Airbrake.notify(notice)
-      end
+    def notify_error(batch_id, error)
+      return unless defined?(Airbrake)
+
+      notice = Airbrake.build_notice(error)
+      notice[:context][:component] = "raif_poll_model_completion_batch_job"
+      notice[:params] = { batch_id: batch_id }
+      Airbrake.notify(notice)
     end
 
   end

--- a/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
+++ b/spec/jobs/raif/poll_model_completion_batch_job_spec.rb
@@ -171,6 +171,54 @@ RSpec.describe Raif::PollModelCompletionBatchJob, type: :job do
       end.not_to have_enqueued_job(described_class)
     end
 
+    describe "error notification" do
+      # Hosts that load airbrake-ruby get notified via the global Airbrake
+      # constant. We don't depend on the gem, so we stub a minimal interface to
+      # pin the behavior: transient errors stay silent (they self-heal via
+      # reschedule); non-transient errors notify before re-raising.
+      let(:airbrake_stub) { class_double("Airbrake", build_notice: notice, notify: nil) }
+      let(:notice) { { context: {}, params: {} } }
+
+      before do
+        stub_const("Airbrake", airbrake_stub)
+      end
+
+      it "does not notify Airbrake when a transient error reschedules the chain" do
+        allow(llm_double).to receive(:fetch_batch_status!).and_raise(Faraday::ServerError.new("503 from provider"))
+        allow(Raif.config).to receive(:model_completion_batch_poll_schedule).and_return([60.seconds])
+
+        described_class.perform_now(batch.id, attempt: 1)
+
+        expect(airbrake_stub).not_to have_received(:notify)
+      end
+
+      it "does not notify Airbrake when a transient error fires against an already-finalized batch" do
+        allow(llm_double).to receive(:fetch_batch_status!) do |b|
+          Raif::ModelCompletionBatch.where(id: b.id).update_all(
+            status: "failed", failed_at: Time.current, handler_dispatched_at: Time.current
+          )
+          raise Faraday::TimeoutError, "transient"
+        end
+
+        described_class.perform_now(batch.id, attempt: 1)
+
+        expect(airbrake_stub).not_to have_received(:notify)
+      end
+
+      it "notifies Airbrake before re-raising a non-transient error" do
+        allow(llm_double).to receive(:fetch_batch_status!).and_raise(StandardError, "non-transient")
+
+        expect do
+          described_class.perform_now(batch.id, attempt: 1)
+        end.to raise_error(StandardError, "non-transient")
+
+        expect(airbrake_stub).to have_received(:build_notice).once
+        expect(airbrake_stub).to have_received(:notify).with(notice).once
+        expect(notice[:context][:component]).to eq("raif_poll_model_completion_batch_job")
+        expect(notice[:params]).to eq({ batch_id: batch.id })
+      end
+    end
+
     it "does not reschedule on transient error if the batch reloaded into terminal + handler already dispatched" do
       allow(llm_double).to receive(:fetch_batch_status!) do |b|
         # Simulate a separate process having fully finalized the batch concurrently:


### PR DESCRIPTION
## Summary

`Raif::PollModelCompletionBatchJob#perform` was unconditionally calling `log_and_notify_error` from its rescue block, so every transient provider error (e.g. `Faraday::ServerError` on a Gemini batch endpoint 503) produced an Airbrake notice even though the job's `transient_error?` branch immediately rescheduled the polling chain. The host got per-blip noise that didn't correspond to actionable work.

## The fix

- Split `log_and_notify_error` into `log_error` (always called) and `notify_error` (called only on the non-transient re-raise path).
- Transient errors stay in the error log for forensics. They still self-heal via reschedule (or no-op when another process has already finalized the batch), so the host's error tracker doesn't need to see them.
- Non-transient errors notify and re-raise as before - behavior on the actually-actionable path is unchanged.

The Airbrake interface is still gated on `defined?(Airbrake)`, so hosts without the gem are unaffected.

## Why now

We were seeing recurring Airbrake notices in production for `Faraday::ServerError` (503 from `generativelanguage.googleapis.com/v1beta/batches/...`) on the poll job - one per provider blip, even though each one was followed by a successful retry. Different provider, same shape across the retriable-exception list.

This complements #477 (idempotent `finalize!` so transient `fetch_results!` failures don't strand batches): #477 made the chain self-heal correctly; this PR stops paging the host every time the self-heal kicks in.

## Test plan

- [x] Three new specs in `spec/jobs/raif/poll_model_completion_batch_job_spec.rb` (uses `stub_const("Airbrake", class_double(...))` to pin the interface, since Raif itself doesn't depend on the gem):
  - Transient error that triggers a reschedule does NOT call `Airbrake.notify`.
  - Transient error against an already-finalized batch (the no-reschedule branch) does NOT call `Airbrake.notify`.
  - Non-transient error DOES call `Airbrake.notify` before re-raising, with the expected `context[:component]` and `params[:batch_id]`.
- [x] Existing transient-reschedule and non-transient-re-raise specs unchanged and still pass.
- [x] Full suite: 1326 examples, 0 failures, 4 pending.
