### PR TITLE
Retry batch HTTP calls on transient errors

### DIFF
--- a/app/models/raif/concerns/llms/anthropic/batch_inference.rb
+++ b/app/models/raif/concerns/llms/anthropic/batch_inference.rb
@@ -37,8 +37,10 @@ module Raif::Concerns::Llms::Anthropic::BatchInference
       { custom_id: mc.batch_custom_id, params: build_request_parameters(mc) }
     end
 
-    response = batch_connection.post("messages/batches") do |req|
-      req.body = { requests: requests }
+    response = with_batch_transient_retry(:submit, batch_id: batch.id) do
+      batch_connection.post("messages/batches") do |req|
+        req.body = { requests: requests }
+      end
     end
 
     body = response.body
@@ -67,7 +69,9 @@ module Raif::Concerns::Llms::Anthropic::BatchInference
   end
 
   def fetch_batch_status!(batch)
-    response = batch_connection.get("messages/batches/#{batch.provider_batch_id}")
+    response = with_batch_transient_retry(:fetch_status, batch_id: batch.id) do
+      batch_connection.get("messages/batches/#{batch.provider_batch_id}")
+    end
     body = response.body
     new_status = map_processing_status(body["processing_status"])
 
@@ -104,7 +108,9 @@ module Raif::Concerns::Llms::Anthropic::BatchInference
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} has no provider_batch_id" if batch.provider_batch_id.blank?
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} is already terminal (status=#{batch.status})" if batch.terminal?
 
-    response = batch_connection.post("messages/batches/#{batch.provider_batch_id}/cancel")
+    response = with_batch_transient_retry(:cancel, batch_id: batch.id) do
+      batch_connection.post("messages/batches/#{batch.provider_batch_id}/cancel")
+    end
     body = response.body
     new_status = map_processing_status(body["processing_status"])
 
@@ -134,7 +140,9 @@ module Raif::Concerns::Llms::Anthropic::BatchInference
 
     completions_by_id = batch.raif_model_completions.index_by(&:batch_custom_id)
 
-    response = batch_results_connection.get(batch.results_url)
+    response = with_batch_transient_retry(:fetch_results, batch_id: batch.id) do
+      batch_results_connection.get(batch.results_url)
+    end
     body = response.body.to_s
 
     body.each_line do |line|

--- a/app/models/raif/concerns/llms/google/batch_inference.rb
+++ b/app/models/raif/concerns/llms/google/batch_inference.rb
@@ -74,8 +74,10 @@ module Raif::Concerns::Llms::Google::BatchInference
           "split the batch or open multiple batches."
     end
 
-    response = batch_connection.post("models/#{batch.model_api_name}:batchGenerateContent") do |req|
-      req.body = body
+    response = with_batch_transient_retry(:submit, batch_id: batch.id) do
+      batch_connection.post("models/#{batch.model_api_name}:batchGenerateContent") do |req|
+        req.body = body
+      end
     end
 
     response_body = response.body
@@ -107,7 +109,9 @@ module Raif::Concerns::Llms::Google::BatchInference
   end
 
   def fetch_batch_status!(batch)
-    response = batch_connection.get(batch.operation_name)
+    response = with_batch_transient_retry(:fetch_status, batch_id: batch.id) do
+      batch_connection.get(batch.operation_name)
+    end
     body = response.body
     new_status = map_job_state(extract_state(body))
 
@@ -151,7 +155,9 @@ module Raif::Concerns::Llms::Google::BatchInference
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} has no provider_batch_id" if batch.provider_batch_id.blank?
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} is already terminal (status=#{batch.status})" if batch.terminal?
 
-    batch_connection.post("#{batch.operation_name}:cancel")
+    with_batch_transient_retry(:cancel, batch_id: batch.id) do
+      batch_connection.post("#{batch.operation_name}:cancel")
+    end
 
     batch.with_lock do
       return batch.status if batch.terminal?
@@ -170,7 +176,9 @@ module Raif::Concerns::Llms::Google::BatchInference
       # Fall back to a direct fetch in case the polling job's status update
       # didn't capture the response sub-tree (e.g. the success transition
       # happened in a prior process and provider_response was cleared).
-      response = batch_connection.get(batch.operation_name)
+      response = with_batch_transient_retry(:fetch_results, batch_id: batch.id) do
+        batch_connection.get(batch.operation_name)
+      end
       payload = response.body["response"] || response.body
     end
 

--- a/app/models/raif/concerns/llms/open_ai/batch_inference.rb
+++ b/app/models/raif/concerns/llms/open_ai/batch_inference.rb
@@ -43,14 +43,18 @@ module Raif::Concerns::Llms::OpenAi::BatchInference
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} has no child completions" if completions.empty?
 
     jsonl = build_batch_jsonl(completions)
-    input_file_id = upload_batch_input_file!(jsonl)
+    input_file_id = with_batch_transient_retry(:submit_upload_input, batch_id: batch.id) do
+      upload_batch_input_file!(jsonl)
+    end
 
-    response = batch_connection.post("batches") do |req|
-      req.body = {
-        input_file_id: input_file_id,
-        endpoint: batch_endpoint_path,
-        completion_window: Raif.config.open_ai_batch_completion_window
-      }
+    response = with_batch_transient_retry(:submit_create, batch_id: batch.id) do
+      batch_connection.post("batches") do |req|
+        req.body = {
+          input_file_id: input_file_id,
+          endpoint: batch_endpoint_path,
+          completion_window: Raif.config.open_ai_batch_completion_window
+        }
+      end
     end
 
     body = response.body
@@ -79,7 +83,9 @@ module Raif::Concerns::Llms::OpenAi::BatchInference
   end
 
   def fetch_batch_status!(batch)
-    response = batch_connection.get("batches/#{batch.provider_batch_id}")
+    response = with_batch_transient_retry(:fetch_status, batch_id: batch.id) do
+      batch_connection.get("batches/#{batch.provider_batch_id}")
+    end
     body = response.body
     new_status = map_batch_status(body["status"])
 
@@ -118,7 +124,9 @@ module Raif::Concerns::Llms::OpenAi::BatchInference
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} has no provider_batch_id" if batch.provider_batch_id.blank?
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} is already terminal (status=#{batch.status})" if batch.terminal?
 
-    response = batch_connection.post("batches/#{batch.provider_batch_id}/cancel")
+    response = with_batch_transient_retry(:cancel, batch_id: batch.id) do
+      batch_connection.post("batches/#{batch.provider_batch_id}/cancel")
+    end
     body = response.body
     new_status = map_batch_status(body["status"])
 
@@ -332,7 +340,9 @@ private
   end
 
   def apply_batch_jsonl(batch, file_id, completions_by_id)
-    response = batch_files_download_connection.get("files/#{file_id}/content")
+    response = with_batch_transient_retry(:fetch_results_file, batch_id: batch.id) do
+      batch_files_download_connection.get("files/#{file_id}/content")
+    end
     body = response.body.to_s
 
     body.each_line do |line|

--- a/app/models/raif/concerns/llms/supports_batch_inference.rb
+++ b/app/models/raif/concerns/llms/supports_batch_inference.rb
@@ -109,4 +109,22 @@ module Raif::Concerns::Llms::SupportsBatchInference
   def cancel_batch!(batch)
     raise NotImplementedError, "#{self.class.name} must implement #cancel_batch!"
   end
+
+protected
+
+  # Wraps a single batch-API HTTP call in Raif's standard transient-error
+  # retry (Raif.config.llm_request_max_retries on
+  # Raif.config.llm_request_retriable_exceptions). Adapters call this around
+  # individual Faraday calls inside submit_batch! / fetch_batch_status! /
+  # fetch_batch_results! / cancel_batch! so a single upstream 5xx / network
+  # blip self-heals before bubbling up to the host app.
+  #
+  # @param operation [Symbol, String] short operation label appended to the
+  #   provider name in log lines (e.g. :submit, :fetch_status, :upload_input).
+  # @param batch_id [Integer, nil] surfaced in the log line for traceability.
+  def with_batch_transient_retry(operation, batch_id: nil, &block)
+    label = +"#{self.class.name} #{operation}"
+    label << " (batch ##{batch_id})" if batch_id
+    Raif::Utils::TransientRetry.call(label: label, &block)
+  end
 end

--- a/app/models/raif/concerns/llms/x_ai/batch_inference.rb
+++ b/app/models/raif/concerns/llms/x_ai/batch_inference.rb
@@ -59,10 +59,14 @@ module Raif::Concerns::Llms::XAi::BatchInference
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} has no child completions" if completions.empty?
 
     jsonl = build_batch_jsonl(completions)
-    input_file_id = upload_batch_input_file!(jsonl)
+    input_file_id = with_batch_transient_retry(:submit_upload_input, batch_id: batch.id) do
+      upload_batch_input_file!(jsonl)
+    end
 
-    response = batch_connection.post("batches") do |req|
-      req.body = { name: "raif_batch_#{batch.id}", input_file_id: input_file_id }
+    response = with_batch_transient_retry(:submit_create, batch_id: batch.id) do
+      batch_connection.post("batches") do |req|
+        req.body = { name: "raif_batch_#{batch.id}", input_file_id: input_file_id }
+      end
     end
     body = response.body.is_a?(Hash) ? response.body : {}
     provider_batch_id = body["batch_id"] || body["id"]
@@ -95,7 +99,9 @@ module Raif::Concerns::Llms::XAi::BatchInference
   end
 
   def fetch_batch_status!(batch)
-    response = batch_connection.get("batches/#{batch.provider_batch_id}")
+    response = with_batch_transient_retry(:fetch_status, batch_id: batch.id) do
+      batch_connection.get("batches/#{batch.provider_batch_id}")
+    end
     body = response.body
     new_status = derive_batch_status(body, batch)
 
@@ -131,7 +137,9 @@ module Raif::Concerns::Llms::XAi::BatchInference
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} has no provider_batch_id" if batch.provider_batch_id.blank?
     raise Raif::Errors::InvalidBatchError, "Batch ##{batch.id} is already terminal (status=#{batch.status})" if batch.terminal?
 
-    response = batch_connection.post("batches/#{batch.provider_batch_id}:cancel")
+    response = with_batch_transient_retry(:cancel, batch_id: batch.id) do
+      batch_connection.post("batches/#{batch.provider_batch_id}:cancel")
+    end
     body = response.body
     new_status = derive_batch_status(body, batch, post_cancel: true)
 
@@ -166,7 +174,9 @@ module Raif::Concerns::Llms::XAi::BatchInference
       params = {}
       params[:pagination_token] = pagination_token if pagination_token.present?
 
-      response = batch_connection.get("batches/#{batch.provider_batch_id}/results", params)
+      response = with_batch_transient_retry(:fetch_results_page, batch_id: batch.id) do
+        batch_connection.get("batches/#{batch.provider_batch_id}/results", params)
+      end
       body = response.body || {}
 
       Array(body["results"]).each do |raw|

--- a/app/models/raif/llm.rb
+++ b/app/models/raif/llm.rb
@@ -280,43 +280,29 @@ module Raif
       Raif.config.llm_request_retriable_exceptions
     end
 
-    def retry_with_backoff(model_completion)
-      retries = 0
-      max_retries = Raif.config.llm_request_max_retries
-      base_delay = 3
-      max_delay = 30
-
-      begin
-        yield
-      rescue *retriable_exceptions => e
-        retries += 1
-        if retries <= max_retries
-          delay = [base_delay * (2**(retries - 1)), max_delay].min
-          log_retry(e, model_completion, retries, max_retries, delay)
+    def retry_with_backoff(model_completion, &block)
+      Raif::Utils::TransientRetry.call(
+        label: "Raif::Llm##{api_name} perform_model_completion",
+        on_retry: ->(error, attempt, max_retries, delay) {
+          log_blank_response_retry(error, model_completion, attempt, max_retries, delay)
           model_completion.increment!(:retry_count)
-          sleep delay
-          retry
-        else
-          Raif.logger.error("LLM API request failed after #{max_retries} retries. Last error: #{e.message}")
-          raise
-        end
-      end
+        },
+        &block
+      )
     end
 
-    def log_retry(error, model_completion, attempt, max_retries, delay)
-      if error.is_a?(Raif::Errors::BlankResponseError)
-        has_reasoning = model_completion.response_array&.any? do |block|
-          block.is_a?(Hash) ? block.key?("reasoning_content") : block.respond_to?(:reasoning_content)
-        end
-        Raif.logger.warn(
-          "Blank response retry #{attempt}/#{max_retries} for #{api_name} " \
-            "(ModelCompletion##{model_completion.id}, source: #{model_completion.source_type}##{model_completion.source_id}, " \
-            "completion_tokens: #{model_completion.completion_tokens}, reasoning_content_present: #{has_reasoning}). " \
-            "Waiting #{delay} seconds..."
-        )
-      else
-        Raif.logger.warn("Retrying LLM API request after error: #{error.message}. Attempt #{attempt}/#{max_retries}. Waiting #{delay} seconds...")
+    def log_blank_response_retry(error, model_completion, attempt, max_retries, delay)
+      return unless error.is_a?(Raif::Errors::BlankResponseError)
+
+      has_reasoning = model_completion.response_array&.any? do |block|
+        block.is_a?(Hash) ? block.key?("reasoning_content") : block.respond_to?(:reasoning_content)
       end
+      Raif.logger.warn(
+        "Blank response retry #{attempt}/#{max_retries} for #{api_name} " \
+          "(ModelCompletion##{model_completion.id}, source: #{model_completion.source_type}##{model_completion.source_id}, " \
+          "completion_tokens: #{model_completion.completion_tokens}, reasoning_content_present: #{has_reasoning}). " \
+          "Waiting #{delay} seconds..."
+      )
     end
 
     def streaming_response_type

--- a/lib/raif/utils.rb
+++ b/lib/raif/utils.rb
@@ -5,4 +5,5 @@ module Raif::Utils
   require "raif/utils/html_to_markdown_converter"
   require "raif/utils/html_fragment_processor"
   require "raif/utils/colors"
+  require "raif/utils/transient_retry"
 end

--- a/lib/raif/utils/transient_retry.rb
+++ b/lib/raif/utils/transient_retry.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Retries a block on transient errors using exponential backoff.
+#
+# Single source of truth for "retry the HTTP call on a network blip" across
+# Raif's synchronous (Raif::Llm#perform_model_completion!) and batch
+# (Raif::Concerns::Llms::*::BatchInference) paths.
+#
+# Defaults to Raif.config.llm_request_max_retries and
+# Raif.config.llm_request_retriable_exceptions so retry behavior moves
+# together when hosts tune those.
+class Raif::Utils::TransientRetry
+  DEFAULT_BASE_DELAY = 3
+  DEFAULT_MAX_DELAY = 30
+
+  # @param label [String] short identifier for log lines (e.g. "open_ai
+  #   submit_batch upload"). Surfaces in retry/exhaustion log messages so the
+  #   call site is visible without grepping.
+  # @param max_retries [Integer] retries permitted after the initial attempt.
+  #   Defaults to Raif.config.llm_request_max_retries.
+  # @param retriable_exceptions [Array<Class>] exception classes that trigger
+  #   a retry. Anything else raises immediately. Defaults to
+  #   Raif.config.llm_request_retriable_exceptions.
+  # @param base_delay [Numeric] seconds for the first backoff interval.
+  # @param max_delay [Numeric] cap for the exponential backoff in seconds.
+  # @param on_retry [Proc, nil] optional callback invoked before each sleep
+  #   with (error, attempt, max_retries, delay). Use this to layer call-site
+  #   bookkeeping on top of the default logging (e.g. incrementing a counter).
+  # @yield the block to execute. Re-yielded on each retry.
+  # @return whatever the block returns on its successful attempt.
+  # @raise the original exception once retries are exhausted, or immediately
+  #   for non-retriable exceptions.
+  def self.call(label:, max_retries: nil, retriable_exceptions: nil, base_delay: DEFAULT_BASE_DELAY, max_delay: DEFAULT_MAX_DELAY, on_retry: nil)
+    max_retries ||= Raif.config.llm_request_max_retries
+    retriable_exceptions ||= Raif.config.llm_request_retriable_exceptions
+    retriable_exceptions = Array(retriable_exceptions)
+
+    attempt = 0
+    begin
+      yield
+    rescue *retriable_exceptions => e
+      attempt += 1
+      if attempt <= max_retries
+        delay = [base_delay * (2**(attempt - 1)), max_delay].min
+        on_retry&.call(e, attempt, max_retries, delay)
+        Raif.logger.warn(
+          "Raif::Utils::TransientRetry[#{label}]: retry #{attempt}/#{max_retries} " \
+            "after #{e.class}: #{e.message}. Sleeping #{delay}s."
+        )
+        sleep_for(delay)
+        retry
+      end
+
+      Raif.logger.error(
+        "Raif::Utils::TransientRetry[#{label}]: exhausted #{max_retries} retries. " \
+          "Last error: #{e.class}: #{e.message}"
+      )
+      raise
+    end
+  end
+
+  # Indirection so tests can stub the sleep without monkey-patching Kernel.
+  # Stub via `allow(Raif::Utils::TransientRetry).to receive(:sleep_for)`.
+  def self.sleep_for(seconds)
+    sleep(seconds)
+  end
+  private_class_method :sleep_for
+end

--- a/spec/lib/raif/utils/transient_retry_spec.rb
+++ b/spec/lib/raif/utils/transient_retry_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Raif::Utils::TransientRetry do
+  before do
+    allow(described_class).to receive(:sleep_for) # never actually sleep in tests
+  end
+
+  describe ".call" do
+    it "returns the block's value on the first attempt when nothing raises" do
+      attempts = 0
+
+      result = described_class.call(label: "test") do
+        attempts += 1
+        :ok
+      end
+
+      expect(result).to eq(:ok)
+      expect(attempts).to eq(1)
+    end
+
+    it "retries a retriable exception then returns the eventual success value" do
+      attempts = 0
+
+      result = described_class.call(
+        label: "test",
+        max_retries: 2,
+        retriable_exceptions: [Faraday::ServerError]
+      ) do
+        attempts += 1
+        raise Faraday::ServerError, "boom" if attempts < 2
+
+        :recovered
+      end
+
+      expect(result).to eq(:recovered)
+      expect(attempts).to eq(2)
+    end
+
+    it "raises the original exception once retries are exhausted" do
+      attempts = 0
+
+      expect do
+        described_class.call(
+          label: "test",
+          max_retries: 2,
+          retriable_exceptions: [Faraday::ServerError]
+        ) do
+          attempts += 1
+          raise Faraday::ServerError, "always fails"
+        end
+      end.to raise_error(Faraday::ServerError, "always fails")
+
+      # Initial attempt + 2 retries = 3 total attempts
+      expect(attempts).to eq(3)
+    end
+
+    it "passes non-retriable exceptions through immediately without retrying" do
+      attempts = 0
+
+      expect do
+        described_class.call(
+          label: "test",
+          max_retries: 5,
+          retriable_exceptions: [Faraday::ServerError]
+        ) do
+          attempts += 1
+          raise ArgumentError, "fatal"
+        end
+      end.to raise_error(ArgumentError, "fatal")
+
+      expect(attempts).to eq(1)
+    end
+
+    it "invokes on_retry with (error, attempt, max_retries, delay) before each sleep" do
+      observed = []
+      attempts = 0
+
+      described_class.call(
+        label: "test",
+        max_retries: 2,
+        retriable_exceptions: [Faraday::ServerError],
+        base_delay: 7,
+        max_delay: 30,
+        on_retry: ->(error, attempt, max_retries, delay) {
+          observed << [error.class, error.message, attempt, max_retries, delay]
+        }
+      ) do
+        attempts += 1
+        raise Faraday::ServerError, "blip ##{attempts}" if attempts < 3
+
+        :done
+      end
+
+      expect(observed).to eq([
+        [Faraday::ServerError, "blip #1", 1, 2, 7],
+        [Faraday::ServerError, "blip #2", 2, 2, 14]
+      ])
+    end
+
+    it "caps the backoff delay at max_delay" do
+      delays = []
+      attempts = 0
+
+      expect do
+        described_class.call(
+          label: "test",
+          max_retries: 4,
+          retriable_exceptions: [Faraday::ServerError],
+          base_delay: 10,
+          max_delay: 12,
+          on_retry: ->(_e, _attempt, _max, delay) { delays << delay }
+        ) do
+          attempts += 1
+          raise Faraday::ServerError, "boom"
+        end
+      end.to raise_error(Faraday::ServerError)
+
+      # base_delay=10 capped at max_delay=12: 10, 12, 12, 12
+      expect(delays).to eq([10, 12, 12, 12])
+    end
+
+    it "defaults max_retries and retriable_exceptions to the Raif.config values" do
+      allow(Raif.config).to receive(:llm_request_max_retries).and_return(1)
+      allow(Raif.config).to receive(:llm_request_retriable_exceptions).and_return([Faraday::TimeoutError])
+
+      attempts = 0
+      expect do
+        described_class.call(label: "test") do
+          attempts += 1
+          raise Faraday::TimeoutError
+        end
+      end.to raise_error(Faraday::TimeoutError)
+
+      # 1 initial + 1 retry = 2 attempts
+      expect(attempts).to eq(2)
+    end
+  end
+end

--- a/spec/models/raif/llm_spec.rb
+++ b/spec/models/raif/llm_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Raif::Llm, type: :model do
           key: :test_retry_llm,
           api_name: "test_retry_api"
         )
-        allow(llm).to receive(:sleep) # Skip sleep delay in tests
+        allow(Raif::Utils::TransientRetry).to receive(:sleep_for) # Skip sleep delay in tests
 
         result = llm.chat(messages: messages)
 
@@ -317,7 +317,7 @@ RSpec.describe Raif::Llm, type: :model do
           key: :test_retry_llm,
           api_name: "test_retry_api"
         )
-        allow(llm).to receive(:sleep) # Skip sleep delay in tests
+        allow(Raif::Utils::TransientRetry).to receive(:sleep_for) # Skip sleep delay in tests
 
         expect(Raif::ModelCompletion.count).to eq(0)
         expect do
@@ -338,7 +338,7 @@ RSpec.describe Raif::Llm, type: :model do
           key: :test_retry_llm,
           api_name: "test_retry_api"
         )
-        allow(llm).to receive(:sleep) # Skip sleep delay in tests
+        allow(Raif::Utils::TransientRetry).to receive(:sleep_for) # Skip sleep delay in tests
 
         expect do
           llm.chat(messages: messages)

--- a/spec/models/raif/llms/bedrock_spec.rb
+++ b/spec/models/raif/llms/bedrock_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Raif::Llms::Bedrock, type: :model do
       allow(Raif.config).to receive(:llm_api_requests_enabled).and_return(true)
       allow(Raif.config).to receive(:llm_request_max_retries).and_return(2)
       allow(Raif.config).to receive(:aws_bedrock_model_name_prefix).and_return(nil)
-      allow(llm).to receive(:sleep)
+      allow(Raif::Utils::TransientRetry).to receive(:sleep_for)
     end
 
     it "retries a blank response and succeeds on a subsequent attempt" do

--- a/spec/models/raif/llms/open_ai_batch_spec.rb
+++ b/spec/models/raif/llms/open_ai_batch_spec.rb
@@ -136,6 +136,31 @@ RSpec.describe Raif::Llms::OpenAiBase, "batch inference" do
       expect(file_stub).not_to have_been_requested
       expect(batch_stub).not_to have_been_requested
     end
+
+    it "retries the /v1/files upload on a transient 520 and succeeds when it recovers" do
+      allow(Raif::Utils::TransientRetry).to receive(:sleep_for)
+
+      file_upload_stub = stub_request(:post, "#{base_url}/files").to_return(
+        { status: 520, body: "Cloudflare upstream unknown error" },
+        {
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { id: "file-input-abc", object: "file", purpose: "batch" }.to_json
+        }
+      )
+      stub_request(:post, "#{base_url}/batches").to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { id: "batch_recovered", status: "in_progress", request_counts: { total: 2 } }.to_json
+      )
+
+      llm.submit_batch!(batch)
+
+      expect(file_upload_stub).to have_been_requested.twice
+      batch.reload
+      expect(batch.provider_batch_id).to eq("batch_recovered")
+      expect(batch.input_file_id).to eq("file-input-abc")
+    end
   end
 
   describe "#fetch_batch_status!" do


### PR DESCRIPTION
## Summary
- A 520 from OpenAI on `POST /v1/files` in `submit_batch!` surfaced straight to the host app as `Faraday::ServerError`. It was the only host-facing batch op with no retry coverage – the sync `chat` path and `PollModelCompletionBatchJob` already handle the same transient class.
- Extracted the retry primitive into `Raif::Utils::TransientRetry` (defaults to `Raif.config.llm_request_max_retries` / `llm_request_retriable_exceptions` so behavior moves together with the sync path) and wrapped every batch-API Faraday call across the OpenAI, Anthropic, Google, and xAI adapters via a new `SupportsBatchInference#with_batch_transient_retry` helper.
- `Raif::Llm#retry_with_backoff` now delegates to the same helper via an `on_retry` callback that preserves `model_completion.retry_count` bookkeeping and blank-response logging.

## What's wrapped

| Provider | Operations now retried |
|---|---|
| OpenAI | `submit_batch!` upload + create as separate retries, `fetch_batch_status!`, `cancel_batch!`, output-file download |
| Anthropic | `submit_batch!`, `fetch_batch_status!`, `cancel_batch!`, `fetch_batch_results!` |
| Google | `submit_batch!`, `fetch_batch_status!`, `cancel_batch!`, `fetch_batch_results!` fallback fetch |
| xAI | `submit_batch!` upload + create, `fetch_batch_status!`, `cancel_batch!`, paginated `fetch_batch_results!` |

The polling job's existing transient-error rescue stays in place as a second-line defense for errors that survive the inner retries.

## Test plan

- [x] `bundle exec rspec spec/lib/raif/utils/transient_retry_spec.rb` (7 new examples covering success-on-first-try, retry-then-success, exhaustion raises, non-retriable passthrough, on_retry callback signature, backoff capping, defaults from config)
- [x] `bundle exec rspec spec/models/raif/llms/open_ai_batch_spec.rb` – new integration test proves `submit_batch!` recovers from a 520 on `/v1/files` (the original Airbrake scenario)
- [x] `bundle exec rspec spec/models/raif/llm_spec.rb spec/models/raif/llms/bedrock_spec.rb` – pre-existing retry tests updated to stub `Raif::Utils::TransientRetry.sleep_for` instead of `llm.sleep`
- [x] Full suite: 1334 examples, 0 failures, 4 pending (unchanged)
