### PR TITLE
stub_raif_task: coerce non-String block results to JSON

### DIFF
--- a/spec/support/rspec_helpers.rb
+++ b/spec/support/rspec_helpers.rb
@@ -8,7 +8,10 @@ module Raif
 
       allow(test_llm).to receive(:perform_model_completion!) do |model_completion, &streaming_block|
         result = block.call(model_completion.messages, model_completion, source_instance)
-        model_completion.raw_response = result if result.is_a?(String)
+        model_completion.raw_response = case result
+        when String, nil then result
+        else result.to_json
+        end
         model_completion.completion_tokens = rand(100..2000)
         model_completion.prompt_tokens = rand(100..2000)
         model_completion.total_tokens = model_completion.completion_tokens + model_completion.prompt_tokens


### PR DESCRIPTION
## Summary

`stub_raif_task` (and `stub_raif_conversation` / `stub_raif_agent`, which share `stubbed_llm`) only assigned `raw_response` when the block returned a `String`. When the block returned a `Hash` (or any other non-`String`, non-`nil` value), `raw_response` was left blank, the task raised `Raif::Errors::BlankResponseError`, and `retry_with_backoff` then slept through the full sequence (default base 3s × 2^n up to `llm_request_max_retries`). With `llm_request_max_retries = 4`, that's 3+6+12+24 = **45 seconds of `sleep`** per affected example before the test could continue.

The most common authoring mistake that triggers this is returning a `Hash` without an explicit `.to_json`:

\`\`\`ruby
stub_raif_task(SomeTask) do
  { "post_title" => "...", "post_content" => "..." }   # silently slow
end
\`\`\`

This change coerces any non-`String`, non-`nil` block return through `.to_json` before assignment, so the intent above just works. `String` and `nil` returns are unchanged.

This was discovered while profiling the test suite of a downstream app: three otherwise-fast examples were each taking ~45s with that exact retry-pattern signature.

## Test plan

- [ ] CI passes (raif's own spec suite, which already returns Strings from `stub_raif_*` blocks, should be unaffected
- [ ] Manual verification in downstream app: examples that previously slept ~45s now complete in normal time
EOF
)