### PR TITLE
Skip TransientRetry sleep globally in RSpec

### DIFF
--- a/spec/lib/raif/utils/transient_retry_spec.rb
+++ b/spec/lib/raif/utils/transient_retry_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Raif::Utils::TransientRetry do
-  before do
-    allow(described_class).to receive(:sleep_for) # never actually sleep in tests
-  end
-
   describe ".call" do
     it "returns the block's value on the first attempt when nothing raises" do
       attempts = 0

--- a/spec/models/raif/llm_spec.rb
+++ b/spec/models/raif/llm_spec.rb
@@ -300,7 +300,6 @@ RSpec.describe Raif::Llm, type: :model do
           key: :test_retry_llm,
           api_name: "test_retry_api"
         )
-        allow(Raif::Utils::TransientRetry).to receive(:sleep_for) # Skip sleep delay in tests
 
         result = llm.chat(messages: messages)
 
@@ -317,7 +316,6 @@ RSpec.describe Raif::Llm, type: :model do
           key: :test_retry_llm,
           api_name: "test_retry_api"
         )
-        allow(Raif::Utils::TransientRetry).to receive(:sleep_for) # Skip sleep delay in tests
 
         expect(Raif::ModelCompletion.count).to eq(0)
         expect do
@@ -338,7 +336,6 @@ RSpec.describe Raif::Llm, type: :model do
           key: :test_retry_llm,
           api_name: "test_retry_api"
         )
-        allow(Raif::Utils::TransientRetry).to receive(:sleep_for) # Skip sleep delay in tests
 
         expect do
           llm.chat(messages: messages)

--- a/spec/models/raif/llms/bedrock_spec.rb
+++ b/spec/models/raif/llms/bedrock_spec.rb
@@ -351,7 +351,6 @@ RSpec.describe Raif::Llms::Bedrock, type: :model do
       allow(Raif.config).to receive(:llm_api_requests_enabled).and_return(true)
       allow(Raif.config).to receive(:llm_request_max_retries).and_return(2)
       allow(Raif.config).to receive(:aws_bedrock_model_name_prefix).and_return(nil)
-      allow(Raif::Utils::TransientRetry).to receive(:sleep_for)
     end
 
     it "retries a blank response and succeeds on a subsequent attempt" do

--- a/spec/models/raif/llms/open_ai_batch_spec.rb
+++ b/spec/models/raif/llms/open_ai_batch_spec.rb
@@ -138,8 +138,6 @@ RSpec.describe Raif::Llms::OpenAiBase, "batch inference" do
     end
 
     it "retries the /v1/files upload on a transient 520 and succeeds when it recovers" do
-      allow(Raif::Utils::TransientRetry).to receive(:sleep_for)
-
       file_upload_stub = stub_request(:post, "#{base_url}/files").to_return(
         { status: 520, body: "Cloudflare upstream unknown error" },
         {

--- a/spec/support/rspec_helpers.rb
+++ b/spec/support/rspec_helpers.rb
@@ -73,3 +73,13 @@ module Raif
 
   end
 end
+
+RSpec.configure do |config|
+  # Skip the exponential-backoff sleep so retry-driven tests (and tests that
+  # hit retries unintentionally, e.g. a stub that returns blank) don't burn
+  # wall time. Retry semantics -- count, logging, eventual raise -- are
+  # preserved; only the sleep is bypassed.
+  config.before(:each) do
+    allow(Raif::Utils::TransientRetry).to receive(:sleep_for)
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `before(:each)` hook in `spec/support/rspec_helpers.rb` (loaded transitively by host apps via `require "raif/rspec"`) that stubs `Raif::Utils::TransientRetry.sleep_for`. Retry semantics (attempt count, logging, `on_retry` callbacks, eventual raise after `max_retries`) are preserved -- only the `sleep` is bypassed.

**Motivation:** when a stub produced a blank `raw_response` (or any retriable error), the test fell through the full exponential-backoff path. With `llm_request_max_retries = 4` and `base_delay = 3`, that's `3+6+12+24 = 45 seconds` of pure sleep per affected example. In a stubbed test the LLM returns the same value on every attempt, so the sleep adds no signal -- only wall time. This was found while profiling a downstream app, where three otherwise-unremarkable specs were each sleeping ~45s on every CI run.

Also removes five now-redundant per-spec stubs of `sleep_for` (in `llm_spec.rb`, `bedrock_spec.rb`, `open_ai_batch_spec.rb`) plus the defensive stub in `transient_retry_spec.rb` itself -- they're now covered by the global hook.

> Note: the commit on this branch landed with a stale, unrelated commit message (a `/tmp/commit_msg.txt` from a different session was used by accident, and force-push isn't an option in this repo's workflow). The actual diff matches this PR description. Squash-merging will replace the message anyway.

## Test plan

- [ ] raif's own spec suite passes in CI
- [ ] Specs that exercise retry paths (`llm_spec.rb`'s retriable contexts, `transient_retry_spec.rb`, batch retry tests) still pass and now run without per-spec `sleep_for` stubs
- [ ] Downstream verification: arc's two remaining `BlankResponseError` outliers (45s each) drop to normal runtime
