### PR TITLE
Document Tuning Engines OpenAI-compatible configuration

### DIFF
--- a/docs/_getting_started/setup.md
+++ b/docs/_getting_started/setup.md
@@ -112,6 +112,26 @@ Currently supported OpenAI Completions API models:
 - `open_ai_o1_mini`
 
 
+### OpenAI-Compatible Gateways
+
+Raif's OpenAI adapters can also point at an OpenAI-compatible gateway by setting `open_ai_base_url` and, for embeddings, `open_ai_embedding_base_url`. This is useful when a Rails app wants to keep Raif's task, conversation, agent, and admin workflows while routing model calls through a governed endpoint.
+
+For example, Rails teams using [Tuning Engines](https://www.tuningengines.com/) can route Raif calls through Tuning Engines for centralized model routing, policy controls, audit logs, traces, approvals, and cost visibility:
+
+```ruby
+Raif.configure do |config|
+  config.open_ai_api_key = ENV["TUNING_ENGINES_API_KEY"]
+  config.open_ai_models_enabled = true
+  config.open_ai_base_url = "https://api.tuningengines.com/v1"
+
+  # Optional: route embeddings through the same governed endpoint.
+  config.open_ai_embedding_models_enabled = true
+  config.open_ai_embedding_base_url = "https://api.tuningengines.com/v1"
+end
+```
+
+Register the model names exposed by your Tuning Engines tenant as regular Raif LLMs. See [Adding LLM Models](../learn_more/customization#adding-llm-models) for the registry pattern.
+
 ## Anthropic
 
 The Anthropic adapter provides access to [provider-managed tools](../key_raif_concepts/model_tools#provider-managed-tools) for web search and code execution.

--- a/lib/generators/raif/install/templates/initializer.rb
+++ b/lib/generators/raif/install/templates/initializer.rb
@@ -11,7 +11,8 @@ Raif.configure do |config|
   # config.open_ai_embedding_models_enabled = ENV["OPENAI_API_KEY"].present?
 
   # The base URL for OpenAI API requests.
-  # Set this if you want to use the OpenAI adapter with a different provider (e.g. for using Azure instead of OpenAI)
+  # Set this if you want to use the OpenAI adapter with a different provider or gateway
+  # (e.g. Azure OpenAI or a governed OpenAI-compatible endpoint such as Tuning Engines)
   # config.open_ai_base_url = "https://api.openai.com/v1"
 
   # The base URL for OpenAI embedding API requests.


### PR DESCRIPTION
## Summary

- Adds a small documentation example for using Tuning Engines through the existing OpenAI-compatible configuration surface.
- Keeps the project API unchanged: no dependencies, no adapter changes, and no runtime behavior changes.
- Shows how Ruby/Rails teams can keep this project in charge of application, agent, tool, or workflow logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI application code.

This project already supports OpenAI-compatible configuration. The docs change makes that existing capability discoverable for Ruby/Rails teams without asking the project to add a new provider, dependency, SDK, or runtime integration.

## Testing

- `git diff --check`
