### PR TITLE
Strip NUL bytes from agent conversation history before persisting

### DIFF
--- a/app/models/raif/agent.rb
+++ b/app/models/raif/agent.rb
@@ -254,10 +254,27 @@ module Raif
     end
 
     def add_conversation_history_entry(entry)
-      entry_stringified = entry.stringify_keys
+      # Tool results carry arbitrary external content (fetched pages, search
+      # results) that can contain NUL bytes, which Postgres cannot store in a
+      # jsonb column. Strip them before persisting so a single poisoned tool
+      # result doesn't abort the whole agent run.
+      entry_stringified = strip_null_bytes(entry.stringify_keys)
       conversation_history << entry_stringified
       save!
       on_conversation_history_entry.call(entry_stringified) if on_conversation_history_entry.present?
+    end
+
+    def strip_null_bytes(value)
+      case value
+      when String
+        value.delete("\u0000")
+      when Hash
+        value.transform_values { |v| strip_null_bytes(v) }
+      when Array
+        value.map { |v| strip_null_bytes(v) }
+      else
+        value
+      end
     end
 
     def fail_run!(reason)

--- a/spec/models/raif/agent_spec.rb
+++ b/spec/models/raif/agent_spec.rb
@@ -99,4 +99,40 @@ RSpec.describe Raif::Agent, type: :model do
       expect(agent.model_tool_invocation_counts).to eq({})
     end
   end
+
+  describe "#add_conversation_history_entry" do
+    let(:agent) do
+      FB.create(
+        :raif_native_tool_calling_agent,
+        creator: creator,
+        system_prompt: "System prompt",
+        available_model_tools: [
+          "Raif::ModelTools::WikipediaSearch",
+          "Raif::ModelTools::ProviderManaged::WebSearch",
+        ]
+      )
+    end
+
+    # A NUL byte (e.g. from a corrupted scraped page) in a tool result would
+    # otherwise abort the save! with PG::UntranslatableCharacter, since
+    # Postgres cannot store NUL bytes in a jsonb column.
+    it "strips NUL bytes from string, nested hash, and array content before persisting to the jsonb column" do
+      nul = 0.chr
+      entry = {
+        "type" => "tool_call_result",
+        "name" => "fetch_url",
+        "result" => {
+          "content" => "announced later in 2026 in a communiqu#{nul}#{nul}",
+          "links" => ["https://example.com/a#{nul}b", "https://example.com/c"]
+        }
+      }
+
+      expect { agent.send(:add_conversation_history_entry, entry) }.not_to raise_error
+
+      persisted = agent.reload.conversation_history.last
+      expect(persisted["result"]["content"]).to eq("announced later in 2026 in a communiqu")
+      expect(persisted["result"]["links"]).to eq(["https://example.com/ab", "https://example.com/c"])
+      expect(agent.conversation_history.to_json).not_to include(nul)
+    end
+  end
 end


### PR DESCRIPTION
Tool results carry arbitrary external content (fetched pages, search results) that can contain NUL bytes, which Postgres cannot store in a jsonb column. A single poisoned tool result would abort the agent's save! with PG::UntranslatableCharacter, failing the whole run.

Deep-strip NUL bytes from each conversation history entry before persisting, protecting all agent types at the single chokepoint.