### PR TITLE
Add latest LLM models to the registry

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,8 +64,11 @@ en:
       anthropic_claude_4_6_opus: Anthropic Claude 4.6 Opus
       anthropic_claude_4_6_sonnet: Anthropic Claude 4.6 Sonnet
       anthropic_claude_4_7_opus: Anthropic Claude 4.7 Opus
+      anthropic_claude_4_8_opus: Anthropic Claude 4.8 Opus
       anthropic_claude_4_opus: Anthropic Claude 4 Opus
       anthropic_claude_4_sonnet: Anthropic Claude 4 Sonnet
+      anthropic_claude_5_fable: Anthropic Claude Fable 5
+      anthropic_claude_5_sonnet: Anthropic Claude 5 Sonnet
       bedrock_amazon_nova_lite: Amazon Nova Lite (via AWS Bedrock)
       bedrock_amazon_nova_micro: Amazon Nova Micro (via AWS Bedrock)
       bedrock_amazon_nova_pro: Amazon Nova Pro (via AWS Bedrock)
@@ -80,8 +83,11 @@ en:
       bedrock_claude_4_6_opus: Anthropic Claude 4.6 Opus (via AWS Bedrock)
       bedrock_claude_4_6_sonnet: Anthropic Claude 4.6 Sonnet (via AWS Bedrock)
       bedrock_claude_4_7_opus: Anthropic Claude 4.7 Opus (via AWS Bedrock)
+      bedrock_claude_4_8_opus: Anthropic Claude 4.8 Opus (via AWS Bedrock)
       bedrock_claude_4_opus: Anthropic Claude 4 Opus (via AWS Bedrock)
       bedrock_claude_4_sonnet: Anthropic Claude 4 Sonnet (via AWS Bedrock)
+      bedrock_claude_5_fable: Anthropic Claude Fable 5 (via AWS Bedrock)
+      bedrock_claude_5_sonnet: Anthropic Claude 5 Sonnet (via AWS Bedrock)
       bedrock_deepseek_r1: DeepSeek R1 (via AWS Bedrock)
       bedrock_deepseek_v3_2: DeepSeek v3.2 (via AWS Bedrock)
       bedrock_gpt_oss_120b: OpenAI GPT-OSS 120B (via AWS Bedrock)
@@ -92,6 +98,7 @@ en:
       google_gemini_3_0_pro: Google Gemini 3 Pro
       google_gemini_3_1_flash_lite: Google Gemini 3.1 Flash-Lite
       google_gemini_3_1_pro: Google Gemini 3.1 Pro
+      google_gemini_3_5_flash: Google Gemini 3.5 Flash
       open_ai_gpt_3_5_turbo: OpenAI GPT-3.5 Turbo
       open_ai_gpt_4_1: OpenAI GPT-4.1
       open_ai_gpt_4_1_mini: OpenAI GPT-4.1 Mini
@@ -105,6 +112,7 @@ en:
       open_ai_gpt_5_4: OpenAI GPT-5.4
       open_ai_gpt_5_4_mini: OpenAI GPT-5.4 Mini
       open_ai_gpt_5_4_nano: OpenAI GPT-5.4 Nano
+      open_ai_gpt_5_5: OpenAI GPT-5.5
       open_ai_gpt_5_mini: OpenAI GPT-5 Mini
       open_ai_gpt_5_nano: OpenAI GPT-5 Nano
       open_ai_o1: OpenAI o1
@@ -127,6 +135,8 @@ en:
       open_ai_responses_gpt_5_4_mini: OpenAI GPT-5.4 Mini (Responses API)
       open_ai_responses_gpt_5_4_nano: OpenAI GPT-5.4 Nano (Responses API)
       open_ai_responses_gpt_5_4_pro: OpenAI GPT-5.4 Pro (Responses API)
+      open_ai_responses_gpt_5_5: OpenAI GPT-5.5 (Responses API)
+      open_ai_responses_gpt_5_5_pro: OpenAI GPT-5.5 Pro (Responses API)
       open_ai_responses_gpt_5_mini: OpenAI GPT-5 Mini (Responses API)
       open_ai_responses_gpt_5_nano: OpenAI GPT-5 Nano (Responses API)
       open_ai_responses_gpt_5_pro: OpenAI GPT-5 Pro (Responses API)
@@ -138,6 +148,9 @@ en:
       open_ai_responses_o3_pro: OpenAI o3 Pro (Responses API)
       open_ai_responses_o4_mini: OpenAI o4 Mini (Responses API)
       open_router_claude_3_7_sonnet: Anthropic Claude 3.7 Sonnet (via OpenRouter)
+      open_router_claude_4_8_opus: Anthropic Claude 4.8 Opus (via OpenRouter)
+      open_router_claude_5_fable: Anthropic Claude Fable 5 (via OpenRouter)
+      open_router_claude_5_sonnet: Anthropic Claude 5 Sonnet (via OpenRouter)
       open_router_deepseek_chat_v3: DeepSeek Chat v3 (via OpenRouter)
       open_router_deepseek_v3_1: DeepSeek v3.1 (via OpenRouter)
       open_router_deepseek_v3_2: DeepSeek v3.2 (via OpenRouter)
@@ -146,6 +159,7 @@ en:
       open_router_gemini_2_5_pro: Gemini 2.5 Pro (via OpenRouter)
       open_router_gemini_3_1_flash_lite_preview: Gemini 3.1 Flash-Lite Preview (via OpenRouter)
       open_router_gemini_3_1_pro_preview: Gemini 3.1 Pro Preview (via OpenRouter)
+      open_router_gemini_3_5_flash: Gemini 3.5 Flash (via OpenRouter)
       open_router_gemini_3_pro_preview: Gemini 3 Pro Preview (via OpenRouter)
       open_router_google_gemma_4_31b_it: Google Gemma 4 31B IT (via OpenRouter)
       open_router_grok_4: Grok 4 (via OpenRouter)

--- a/lib/raif/llm_registry.rb
+++ b/lib/raif/llm_registry.rb
@@ -42,6 +42,13 @@ module Raif
   def self.default_llms
     open_ai_models = [
       {
+        key: :open_ai_gpt_5_5,
+        api_name: "gpt-5.5",
+        input_token_cost: 5.0 / 1_000_000,
+        output_token_cost: 30.0 / 1_000_000,
+        model_provider_settings: { supports_temperature: false },
+      },
+      {
         key: :open_ai_gpt_5_4,
         api_name: "gpt-5.4",
         input_token_cost: 2.5 / 1_000_000,
@@ -233,10 +240,54 @@ module Raif
       model_provider_settings: { supports_temperature: false, supports_structured_outputs: false },
     }
 
+    open_ai_responses_models << {
+      key: :open_ai_responses_gpt_5_5_pro,
+      api_name: "gpt-5.5-pro",
+      input_token_cost: 30.0 / 1_000_000,
+      output_token_cost: 180.0 / 1_000_000,
+      model_provider_settings: { supports_temperature: false },
+    }
+
     {
       Raif::Llms::OpenAiCompletions => open_ai_models,
       Raif::Llms::OpenAiResponses => open_ai_responses_models,
       Raif::Llms::Anthropic => [
+        {
+          key: :anthropic_claude_5_fable,
+          api_name: "claude-fable-5",
+          input_token_cost: 10.0 / 1_000_000,
+          output_token_cost: 50.0 / 1_000_000,
+          max_completion_tokens: 128_000,
+          model_provider_settings: { supports_temperature: false, supports_structured_outputs: true },
+          supported_provider_managed_tools: [
+            Raif::ModelTools::ProviderManaged::WebSearch,
+            Raif::ModelTools::ProviderManaged::CodeExecution
+          ]
+        },
+        {
+          key: :anthropic_claude_4_8_opus,
+          api_name: "claude-opus-4-8",
+          input_token_cost: 5.0 / 1_000_000,
+          output_token_cost: 25.0 / 1_000_000,
+          max_completion_tokens: 128_000,
+          model_provider_settings: { supports_temperature: false, supports_structured_outputs: true },
+          supported_provider_managed_tools: [
+            Raif::ModelTools::ProviderManaged::WebSearch,
+            Raif::ModelTools::ProviderManaged::CodeExecution
+          ]
+        },
+        {
+          key: :anthropic_claude_5_sonnet,
+          api_name: "claude-sonnet-5",
+          input_token_cost: 3.0 / 1_000_000,
+          output_token_cost: 15.0 / 1_000_000,
+          max_completion_tokens: 128_000,
+          model_provider_settings: { supports_temperature: false, supports_structured_outputs: true },
+          supported_provider_managed_tools: [
+            Raif::ModelTools::ProviderManaged::WebSearch,
+            Raif::ModelTools::ProviderManaged::CodeExecution
+          ]
+        },
         {
           key: :anthropic_claude_4_7_opus,
           api_name: "claude-opus-4-7",
@@ -385,6 +436,30 @@ module Raif
       ],
       Raif::Llms::Bedrock => [
         {
+          key: :bedrock_claude_5_fable,
+          api_name: "anthropic.claude-fable-5",
+          input_token_cost: 0.010 / 1000,
+          output_token_cost: 0.050 / 1000,
+          max_completion_tokens: 128_000,
+          model_provider_settings: { supports_structured_outputs: true }
+        },
+        {
+          key: :bedrock_claude_4_8_opus,
+          api_name: "anthropic.claude-opus-4-8",
+          input_token_cost: 0.005 / 1000,
+          output_token_cost: 0.025 / 1000,
+          max_completion_tokens: 128_000,
+          model_provider_settings: { supports_structured_outputs: true }
+        },
+        {
+          key: :bedrock_claude_5_sonnet,
+          api_name: "anthropic.claude-sonnet-5",
+          input_token_cost: 0.003 / 1000,
+          output_token_cost: 0.015 / 1000,
+          max_completion_tokens: 128_000,
+          model_provider_settings: { supports_structured_outputs: true }
+        },
+        {
           key: :bedrock_claude_4_7_opus,
           api_name: "anthropic.claude-opus-4-7",
           input_token_cost: 0.005 / 1000,
@@ -532,6 +607,24 @@ module Raif
       ],
       Raif::Llms::OpenRouter => [
         {
+          key: :open_router_claude_5_fable,
+          api_name: "anthropic/claude-fable-5",
+          input_token_cost: 10.0 / 1_000_000,
+          output_token_cost: 50.0 / 1_000_000,
+        },
+        {
+          key: :open_router_claude_4_8_opus,
+          api_name: "anthropic/claude-opus-4.8",
+          input_token_cost: 5.0 / 1_000_000,
+          output_token_cost: 25.0 / 1_000_000,
+        },
+        {
+          key: :open_router_claude_5_sonnet,
+          api_name: "anthropic/claude-sonnet-5",
+          input_token_cost: 3.0 / 1_000_000,
+          output_token_cost: 15.0 / 1_000_000,
+        },
+        {
           key: :open_router_claude_3_7_sonnet,
           api_name: "anthropic/claude-3.7-sonnet",
           input_token_cost: 3.0 / 1_000_000,
@@ -566,6 +659,12 @@ module Raif
           api_name: "google/gemini-2.5-flash",
           input_token_cost: 0.3 / 1_000_000,
           output_token_cost: 2.5 / 1_000_000,
+        },
+        {
+          key: :open_router_gemini_3_5_flash,
+          api_name: "google/gemini-3.5-flash",
+          input_token_cost: 1.5 / 1_000_000,
+          output_token_cost: 9.0 / 1_000_000,
         },
         {
           key: :open_router_gemini_2_5_pro,
@@ -715,6 +814,16 @@ module Raif
         },
       ],
       Raif::Llms::Google => [
+        {
+          key: :google_gemini_3_5_flash,
+          api_name: "gemini-3.5-flash",
+          input_token_cost: 1.5 / 1_000_000,
+          output_token_cost: 9.0 / 1_000_000,
+          supported_provider_managed_tools: [
+            Raif::ModelTools::ProviderManaged::WebSearch,
+            Raif::ModelTools::ProviderManaged::CodeExecution
+          ]
+        },
         {
           key: :google_gemini_3_1_pro,
           api_name: "gemini-3.1-pro-preview",

--- a/lib/raif/llm_registry.rb
+++ b/lib/raif/llm_registry.rb
@@ -440,24 +440,21 @@ module Raif
           api_name: "anthropic.claude-fable-5",
           input_token_cost: 0.010 / 1000,
           output_token_cost: 0.050 / 1000,
-          max_completion_tokens: 128_000,
-          model_provider_settings: { supports_structured_outputs: true }
+          max_completion_tokens: 128_000
         },
         {
           key: :bedrock_claude_4_8_opus,
           api_name: "anthropic.claude-opus-4-8",
           input_token_cost: 0.005 / 1000,
           output_token_cost: 0.025 / 1000,
-          max_completion_tokens: 128_000,
-          model_provider_settings: { supports_structured_outputs: true }
+          max_completion_tokens: 128_000
         },
         {
           key: :bedrock_claude_5_sonnet,
           api_name: "anthropic.claude-sonnet-5",
           input_token_cost: 0.003 / 1000,
           output_token_cost: 0.015 / 1000,
-          max_completion_tokens: 128_000,
-          model_provider_settings: { supports_structured_outputs: true }
+          max_completion_tokens: 128_000
         },
         {
           key: :bedrock_claude_4_7_opus,


### PR DESCRIPTION
Register the mid-2026 model releases and their display names:

- Anthropic: Claude Sonnet 5, Opus 4.8, and Fable 5 (direct API, AWS Bedrock, and OpenRouter)
- OpenAI: GPT-5.5 (Completions + Responses) and GPT-5.5 Pro
- Google: Gemini 3.5 Flash (direct API and OpenRouter)

Pricing, context windows, and API names follow the current provider docs. Note that Fable 5 requires provider_data_share on Bedrock, which AWS has since restricted; the direct and OpenRouter entries work.

Note: Claude Sonnet 5 pricing is using the post-launch standard rate now. Anthropic and AWS both list $2 input / $10 output per MTok through August 31, 2026, then $3 / $15 starting September 1, 2026. The registry uses $3 / $15, so current cost estimates are 50% high.