### PR TITLE
Fix agent generator empty process_iteration override

### DIFF
--- a/docs/_key_raif_concepts/agents.md
+++ b/docs/_key_raif_concepts/agents.md
@@ -91,32 +91,29 @@ You can define the system prompt either in the template or by overriding `build_
 ```ruby
 module Raif
   module Agents
-    class WikipediaResearchAgent < Raif::Agent
+    class WikipediaResearchAgent < Raif::ApplicationAgent
       # If you want to always include a certain set of model tools with this agent type,
       # uncomment this callback to populate the available_model_tools attribute with your desired model tools.
-      # before_create -> {
-      #   self.available_model_tools ||= [
+      # def populate_default_model_tools
+      #   self.available_model_tools = [
       #     Raif::ModelTools::WikipediaSearch,
       #     Raif::ModelTools::FetchUrl
       #   ]
-      # }
+      # end
 
-      # Enter your agent's system prompt here. Alternatively, you can define it in
-      # app/views/raif/agents/wikipedia_research_agent.system_prompt.erb
-      def build_system_prompt
-        # TODO: Implement your system prompt here
-      end
-
-      # Each iteration of the agent loop will generate a new Raif::ModelCompletion record and
-      # then call this method with it as an argument.
-      def process_iteration_model_completion(model_completion)
-        # TODO: Implement your iteration processing here
-      end
+      # System prompt is defined in app/views/raif/agents/wikipedia_research_agent.system_prompt.erb
+      # Alternatively, you can change your agent's superclass to an existing agent type
+      # (like Raif::Agents::NativeToolCallingAgent) to utilize an existing system prompt,
+      # or override build_system_prompt directly:
+      # def build_system_prompt
+      #   "Your system prompt here"
+      # end
     end
   end
 end
 
 ```
+
 
 ---
 

--- a/lib/generators/raif/agent/templates/agent.rb.tt
+++ b/lib/generators/raif/agent/templates/agent.rb.tt
@@ -16,11 +16,5 @@
     # def build_system_prompt
     #   "Your system prompt here"
     # end
-
-    # Each iteration of the agent loop will generate a new Raif::ModelCompletion record and
-    # then call this method with it as an argument.
-    def process_iteration_model_completion(model_completion)
-      # TODO: Implement your iteration processing here
-    end
   end
 <% end -%>

--- a/spec/generators/raif/agent_generator_spec.rb
+++ b/spec/generators/raif/agent_generator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Raif::Generators::AgentGenerator, type: :generator do
 
       content = File.read(File.join(tmp_dir, "app/models/raif/application_agent.rb"))
       expect(content).to include("module Raif")
-      expect(content).to include("class ApplicationAgent < Raif::Agent")
+      expect(content).to include("class ApplicationAgent < Raif::Agents::NativeToolCallingAgent")
       expect(content).to include("# Add any shared agent behavior here")
     end
 
@@ -41,9 +41,11 @@ RSpec.describe Raif::Generators::AgentGenerator, type: :generator do
       expect(content).to include("module Raif")
       expect(content).to include("module Agents")
       expect(content).to include("class MyAgent < Raif::ApplicationAgent")
-      expect(content).to include("def build_system_prompt")
-      expect(content).to include("def process_iteration_model_completion")
+      expect(content).to include("# def build_system_prompt")
       expect(content).to include("# def populate_default_model_tools")
+      # Must not override NativeToolCallingAgent#process_iteration_model_completion
+      # with an empty stub — that would prevent tool calling and final answers.
+      expect(content).not_to include("def process_iteration_model_completion")
     end
 
     it "creates the eval set file" do


### PR DESCRIPTION
Fixes #508

The agent generator was shipping an empty `process_iteration_model_completion` that shadowed `NativeToolCallingAgent`, so tools and final answers never ran.

Removed the stub from the template, aligned the docs example, and updated the generator specs.