### PR TITLE
Fix conversation entries IDOR by scoping lookup to current user

### DIFF
--- a/app/controllers/raif/conversation_entries_controller.rb
+++ b/app/controllers/raif/conversation_entries_controller.rb
@@ -22,7 +22,7 @@ class Raif::ConversationEntriesController < Raif::ApplicationController
 
     @conversation_entry = @conversation.entries.new(conversation_entry_params)
     @conversation_entry.raif_user_tool_invocation = user_tool_invocation
-    @conversation_entry.creator = current_user
+    @conversation_entry.creator = raif_current_user
 
     if @conversation_entry.save
       @conversation.update_columns(generating_entry_response: true)
@@ -33,7 +33,7 @@ class Raif::ConversationEntriesController < Raif::ApplicationController
 private
 
   def set_conversation
-    @conversation = Raif::Conversation.find(params[:conversation_id])
+    @conversation = Raif::Conversation.where(creator: raif_current_user).find(params[:conversation_id])
   end
 
   def conversation_entry_params

--- a/spec/requests/raif/conversation_entries_idor_spec.rb
+++ b/spec/requests/raif/conversation_entries_idor_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Conversation entries creator scoping", type: :request do
+  let(:victim) { FB.create(:raif_test_user) }
+  let(:attacker) { FB.create(:raif_test_user) }
+  let!(:victim_conversation) { FB.create(:raif_conversation, creator: victim) }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(attacker)
+  end
+
+  it "does not let an attacker open the new entry form on another user's conversation" do
+    get "/raif/conversations/#{victim_conversation.id}/entries/new",
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "does not let an attacker create an entry on another user's conversation by id" do
+    post "/raif/conversations/#{victim_conversation.id}/entries",
+      params: { conversation_entry: { user_message: "injected into victim conversation" } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    expect(response).to have_http_status(:not_found)
+    expect(victim_conversation.entries.reload.count).to eq(0)
+  end
+end


### PR DESCRIPTION
Fixes #510

Conversation entry create used a bare `Conversation.find` by id, so any authorized user could post into someone else's conversation. Conversations themselves were already scoped by creator.

Changed files:
- `app/controllers/raif/conversation_entries_controller.rb` - look up the conversation with `where(creator: raif_current_user)`, and set entry creator via `raif_current_user`
- `spec/requests/raif/conversation_entries_idor_spec.rb` - request specs that expect 404 on cross-user `new` and `create`