### PR TITLE
Add OpenAI GPT-5.6 models (Sol, Terra, Luna)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,9 @@ en:
       open_ai_gpt_5_4_mini: OpenAI GPT-5.4 Mini
       open_ai_gpt_5_4_nano: OpenAI GPT-5.4 Nano
       open_ai_gpt_5_5: OpenAI GPT-5.5
+      open_ai_gpt_5_6_luna: OpenAI GPT-5.6 Luna
+      open_ai_gpt_5_6_sol: OpenAI GPT-5.6 Sol
+      open_ai_gpt_5_6_terra: OpenAI GPT-5.6 Terra
       open_ai_gpt_5_mini: OpenAI GPT-5 Mini
       open_ai_gpt_5_nano: OpenAI GPT-5 Nano
       open_ai_o1: OpenAI o1
@@ -126,6 +129,9 @@ en:
       open_ai_responses_gpt_5_4_pro: OpenAI GPT-5.4 Pro (Responses API)
       open_ai_responses_gpt_5_5: OpenAI GPT-5.5 (Responses API)
       open_ai_responses_gpt_5_5_pro: OpenAI GPT-5.5 Pro (Responses API)
+      open_ai_responses_gpt_5_6_luna: OpenAI GPT-5.6 Luna (Responses API)
+      open_ai_responses_gpt_5_6_sol: OpenAI GPT-5.6 Sol (Responses API)
+      open_ai_responses_gpt_5_6_terra: OpenAI GPT-5.6 Terra (Responses API)
       open_ai_responses_gpt_5_mini: OpenAI GPT-5 Mini (Responses API)
       open_ai_responses_gpt_5_nano: OpenAI GPT-5 Nano (Responses API)
       open_ai_responses_gpt_5_pro: OpenAI GPT-5 Pro (Responses API)

--- a/docs/_getting_started/setup.md
+++ b/docs/_getting_started/setup.md
@@ -58,6 +58,9 @@ end
 ```
 
 Currently supported OpenAI Responses API models:
+- `open_ai_responses_gpt_5_6_sol`
+- `open_ai_responses_gpt_5_6_terra`
+- `open_ai_responses_gpt_5_6_luna`
 - `open_ai_responses_gpt_5_5`
 - `open_ai_responses_gpt_5_5_pro`
 - `open_ai_responses_gpt_5_4`
@@ -98,6 +101,9 @@ end
 ```
 
 Currently supported OpenAI Completions API models:
+- `open_ai_gpt_5_6_sol`
+- `open_ai_gpt_5_6_terra`
+- `open_ai_gpt_5_6_luna`
 - `open_ai_gpt_5_5`
 - `open_ai_gpt_5_4`
 - `open_ai_gpt_5_4_mini`

--- a/lib/generators/raif/install/templates/initializer.rb
+++ b/lib/generators/raif/install/templates/initializer.rb
@@ -73,6 +73,9 @@ Raif.configure do |config|
 
   # The default LLM model to use. Defaults to "open_ai_gpt_4o"
   # Available keys:
+  #   open_ai_gpt_5_6_sol
+  #   open_ai_gpt_5_6_terra
+  #   open_ai_gpt_5_6_luna
   #   open_ai_gpt_5_5
   #   open_ai_gpt_5_4
   #   open_ai_gpt_5_4_mini
@@ -93,6 +96,9 @@ Raif.configure do |config|
   #   open_ai_o3
   #   open_ai_o3_mini
   #   open_ai_o1
+  #   open_ai_responses_gpt_5_6_sol
+  #   open_ai_responses_gpt_5_6_terra
+  #   open_ai_responses_gpt_5_6_luna
   #   open_ai_responses_gpt_5_5
   #   open_ai_responses_gpt_5_5_pro
   #   open_ai_responses_gpt_5_4

--- a/lib/raif/llm_registry.rb
+++ b/lib/raif/llm_registry.rb
@@ -42,6 +42,27 @@ module Raif
   def self.default_llms
     open_ai_models = [
       {
+        key: :open_ai_gpt_5_6_sol,
+        api_name: "gpt-5.6-sol",
+        input_token_cost: 5.0 / 1_000_000,
+        output_token_cost: 30.0 / 1_000_000,
+        model_provider_settings: { supports_temperature: false },
+      },
+      {
+        key: :open_ai_gpt_5_6_terra,
+        api_name: "gpt-5.6-terra",
+        input_token_cost: 2.0 / 1_000_000,
+        output_token_cost: 12.0 / 1_000_000,
+        model_provider_settings: { supports_temperature: false },
+      },
+      {
+        key: :open_ai_gpt_5_6_luna,
+        api_name: "gpt-5.6-luna",
+        input_token_cost: 0.20 / 1_000_000,
+        output_token_cost: 1.20 / 1_000_000,
+        model_provider_settings: { supports_temperature: false },
+      },
+      {
         key: :open_ai_gpt_5_5,
         api_name: "gpt-5.5",
         input_token_cost: 5.0 / 1_000_000,


### PR DESCRIPTION
Register gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna on both the
Completions and Responses APIs, with current list pricing. Update the
install generator's initializer comment and the setup docs.

There is no separate Sol Pro model id; the API exposes only sol/terra/luna,
so no pro variant is registered.
