### PR TITLE
Make the interactive Claude workflows inspectable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,6 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # --verbose puts the transcript in the job log; without it the action
-          # logs only its init and result events, so a run cannot be inspected.
-          claude_args: '--verbose'
 
       # This trigger runs the pull request's own copy of this file, so a PR that
       # edits it makes the action refuse its token exchange and skip, reporting
@@ -49,11 +46,14 @@ jobs:
         run: |
           echo "::warning title=Claude review did not run::The action produced no execution log. If this pull request edits .github/workflows/claude-code-review.yml, that is expected: the action only runs when the file matches the version on the default branch, and it will work once merged. Otherwise, download the claude-execution-output artifact to see what happened."
 
-      # The transcript is otherwise unrecoverable once the job log expires, and
-      # the log is awkward to parse. Keep the structured record downloadable.
+      # The only way to read a run. The action hides tool calls and the final
+      # response from the job log unless show_full_output is set, which would
+      # publish every tool result to a publicly visible log. To get that detail
+      # for one run, re-run with debug logging, which the action also honors.
       - name: Upload Claude execution log
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: claude-execution-output
           path: ${{ steps.claude-review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,4 +36,27 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          # --verbose puts the transcript in the job log; without it the action
+          # logs only its init and result events, so a run cannot be inspected.
+          claude_args: '--verbose'
+
+      # This trigger runs the pull request's own copy of this file, so a PR that
+      # edits it makes the action refuse its token exchange and skip, reporting
+      # success in seconds. That is expected here, so say so rather than failing:
+      # an empty execution_file is the only signal the action exposes for it.
+      - name: Note if the review did not run
+        if: always() && steps.claude-review.outputs.execution_file == ''
+        run: |
+          echo "::warning title=Claude review did not run::The action produced no execution log. If this pull request edits .github/workflows/claude-code-review.yml, that is expected: the action only runs when the file matches the version on the default branch, and it will work once merged. Otherwise, download the claude-execution-output artifact to see what happened."
+
+      # The transcript is otherwise unrecoverable once the job log expires, and
+      # the log is awkward to parse. Keep the structured record downloadable.
+      - name: Upload Claude execution log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: claude-execution-output
+          path: ${{ steps.claude-review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+          if-no-files-found: warn
+          retention-days: 30
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,15 +46,16 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # --verbose puts the transcript in the job log; without it the action
-          # logs only its init and result events, so a run cannot be inspected.
-          claude_args: '--verbose'
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
 
-      # The transcript is otherwise unrecoverable once the job log expires, and
-      # the log is awkward to parse. Keep the structured record downloadable.
+      # The only way to read a run. The action hides tool calls and the final
+      # response from the job log unless show_full_output is set, which would
+      # publish every tool result to a publicly visible log. To get that detail
+      # for one run, re-run with debug logging, which the action also honors.
       - name: Upload Claude execution log
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: claude-execution-output
           path: ${{ steps.claude.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,18 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # --verbose puts the transcript in the job log; without it the action
+          # logs only its init and result events, so a run cannot be inspected.
+          claude_args: '--verbose'
+
+      # The transcript is otherwise unrecoverable once the job log expires, and
+      # the log is awkward to parse. Keep the structured record downloadable.
+      - name: Upload Claude execution log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: claude-execution-output
+          path: ${{ steps.claude.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+          if-no-files-found: warn
+          retention-days: 30
 


### PR DESCRIPTION
## Summary

Neither of these workflows left any record of a run. The action streams only its `init` and `result` events to the job log, never tool calls or its final response, so a run that misbehaved could not be reviewed afterwards. That is the same blind spot that hid a broken scheduled check for three runs, each of which reported success while doing nothing.

Both now upload the action's `execution_file` output as an artifact, with a `runner.temp` fallback, `if-no-files-found: warn`, and `continue-on-error: true`, so a diagnostic step can never decide the job result.

The artifact is the only way to read a run. The action hides tool calls and the final response from the job log unless its `show_full_output` input is set, and its own description for that input warns it emits every tool result into logs that are publicly visible, which is not a trade worth making on a public repository. Debug mode gives the same detail per run, on demand, and both workflows now say so in a comment.

## Deliberately not ported from the scheduled check

The scheduled check gained several other things. None of them belong here, for different reasons:

- **No `github_token`.** These trigger on `pull_request`, `issue_comment`, and the review events, so on a public repository a fork can reach them. Supplying a token skips the comparison against the default branch, and that comparison is what stands between untrusted input and an issued token. It is safe on the scheduled check only because `schedule` and `workflow_dispatch` both require write access.
- **No fail-on-empty-log in `claude.yml`.** Comment and review events always run the default branch's copy of a workflow, so its file cannot differ from the default branch and a validation skip cannot occur. A guard there would be dead code, which is worse than no guard.
- **A warning rather than a failure in `claude-code-review.yml`.** That trigger runs the pull request's own copy of the file, so a PR that edits the workflow legitimately trips the skip. Failing would turn every workflow-touching PR red, and the action's own message calls that case normal. The warning names the likely cause so the reader is not left guessing.

## What to expect on this PR

The warning should fire here, because this PR edits `claude-code-review.yml`. That is the case it exists to explain, so it doubles as a demonstration. It also means the artifact path cannot be exercised on this PR: with no execution log there is no file to upload, and the upload step should warn and pass rather than fail. Both behaviours are worth eyeballing in the checks.

`claude.yml` is not exercised by opening a PR at all. Its first real test is the next `@claude` mention.

## Correction from review

The first commit on this branch added `--verbose` and claimed it put the transcript in the job log. It does not. The action gates that on `show_full_output` or Actions debug mode, and nothing in it handles `--verbose` at all. It has been removed rather than papered over; with it gone neither workflow passes `claude_args`, so `claude.yml` returns to the commented-out example it shipped with. The artifact was always the part doing the work.
